### PR TITLE
Correct go module names for use with 'go get' and 'go install' commands

### DIFF
--- a/cmd/levee/main.go
+++ b/cmd/levee/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"google.com/go-flow-levee/internal"
+	"github.com/google/go-flow-levee/internal"
 
 	"golang.org/x/tools/go/analysis/singlechecker"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module google.com/go-flow-levee
+module github.com/google/go-flow-levee
 
 go 1.14
 

--- a/internal/levee.go
+++ b/internal/levee.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/eapache/queue"
 
-	"google.com/go-flow-levee/internal/pkg/config/regexp"
-	"google.com/go-flow-levee/internal/pkg/sanitizer"
-	"google.com/go-flow-levee/internal/pkg/utils"
+	"github.com/google/go-flow-levee/internal/pkg/config/regexp"
+	"github.com/google/go-flow-levee/internal/pkg/sanitizer"
+	"github.com/google/go-flow-levee/internal/pkg/utils"
 )
 
 var configFile string


### PR DESCRIPTION
Prior misunderstanding of `go mod` yielded an incorrect module name.  Use this repository as the source of truth.  `go get` will still fail due to this repo having no non-internal Go code, but this will enable `go install github.com/google/go-flow-levee/cmd/levee`.