### PR TITLE
Move the logic related to determining the name of a field into the utils package.

### DIFF
--- a/internal/levee.go
+++ b/internal/levee.go
@@ -115,13 +115,8 @@ func (c config) isSource(t types.Type) bool {
 func (c config) isSourceFieldAddr(fa *ssa.FieldAddr) bool {
 	// fa.Type() refers to the accessed field's type.
 	// fa.X.Type() refers to the surrounding struct's type.
-
 	deref := utils.Dereference(fa.X.Type())
-	st, ok := deref.Underlying().(*types.Struct)
-	if !ok {
-		return false
-	}
-	fieldName := st.Field(fa.Field).Name()
+	fieldName := utils.FieldName(fa)
 
 	for _, p := range c.Sources {
 		if n, ok := deref.(*types.Named); ok &&

--- a/internal/pkg/utils/testdata/src/fieldname/embedded/test.go
+++ b/internal/pkg/utils/testdata/src/fieldname/embedded/test.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embedded
+
+import "fmt"
+
+type foo struct {
+	name string
+}
+
+type bar struct {
+	*foo
+}
+
+func f() {
+	bar := &bar{foo: &foo{}}
+	fmt.Printf("%v", bar)
+}

--- a/internal/pkg/utils/testdata/src/fieldname/regular/test.go
+++ b/internal/pkg/utils/testdata/src/fieldname/regular/test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regular
+
+import "fmt"
+
+type foo struct {
+	name string
+}
+
+func f() {
+	bar := &foo{name: "n"}
+	fmt.Printf("%v", bar)
+}

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -15,7 +15,10 @@
 // Package utils contains various utility functions.
 package utils
 
-import "go/types"
+import (
+	"go/types"
+	"golang.org/x/tools/go/ssa"
+)
 
 // Dereference returns the underlying type of a pointer.
 // If the input is not a pointer, then the type of the input is returned.
@@ -27,4 +30,17 @@ func Dereference(t types.Type) types.Type {
 		}
 		t = tt.Elem()
 	}
+}
+
+// FieldName returns the name of the field identified by the FieldAddr.
+// It is the responsibility of the caller to ensure that the returned value is a non-empty string.
+func FieldName(fa *ssa.FieldAddr) string {
+	// fa.Type() refers to the accessed field's type.
+	// fa.X.Type() refers to the surrounding struct's type.
+	d := Dereference(fa.X.Type())
+	st, ok := d.Underlying().(*types.Struct)
+	if !ok {
+		return ""
+	}
+	return st.Field(fa.Field).Name()
 }


### PR DESCRIPTION
Move the logic related to determining the name of a field into the utils package.