### PR TITLE
Extract config struct to config package.

### DIFF
--- a/internal/levee.go
+++ b/internal/levee.go
@@ -15,18 +15,15 @@
 package internal
 
 import (
-	"encoding/json"
 	"fmt"
 	"go/types"
-	"io/ioutil"
 	"strings"
-	"sync"
 
+	"github.com/google/go-flow-levee/internal/pkg/config"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"
 
-	"github.com/google/go-flow-levee/internal/pkg/config/regexp"
 	"github.com/google/go-flow-levee/internal/pkg/source"
 	"github.com/google/go-flow-levee/internal/pkg/utils"
 )
@@ -35,266 +32,6 @@ var configFile string
 
 func init() {
 	Analyzer.Flags.StringVar(&configFile, "config", "config.json", "path to analysis configuration file")
-}
-
-// config contains matchers and analysis scope information
-type config struct {
-	Sources                 []sourceMatcher
-	Sinks                   []nameMatcher
-	Sanitizers              []nameMatcher
-	FieldPropagators        []fieldPropagatorMatcher
-	TransformingPropagators []transformingPropagatorMatcher
-	PropagatorArgs          argumentPropagatorMatcher
-	Whitelist               []packageMatcher
-	AnalysisScope           []packageMatcher
-}
-
-// shouldSkip returns true for any function that is outside analysis scope,
-// that is whitelisted,
-// whose containing package imports "testing"
-// or whose containing package does not import any package containing a source or a sink.
-func (c config) shouldSkip(pkg *types.Package) bool {
-	if isTestPkg(pkg) || !c.isInScope(pkg) || c.isWhitelisted(pkg) {
-		return true
-	}
-
-	// TODO Does this skip packages that own sources/sinks but don't import others?
-	for _, im := range pkg.Imports() {
-		for _, s := range c.Sinks {
-			if s.matchPackage(im) {
-				return false
-			}
-		}
-
-		for _, s := range c.Sources {
-			if s.PackageRE.MatchString(im.Path()) {
-				return false
-			}
-		}
-	}
-
-	return true
-}
-
-func (c config) isSink(call *ssa.Call) bool {
-	for _, p := range c.Sinks {
-		if p.matchMethodName(call) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (c config) IsSanitizer(call *ssa.Call) bool {
-	for _, p := range c.Sanitizers {
-		if p.matchMethodName(call) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (c config) isSource(t types.Type) bool {
-	n, ok := t.(*types.Named)
-	if !ok {
-		return false
-	}
-
-	for _, p := range c.Sources {
-		if p.match(n) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c config) IsSourceFieldAddr(fa *ssa.FieldAddr) bool {
-	// fa.Type() refers to the accessed field's type.
-	// fa.X.Type() refers to the surrounding struct's type.
-	deref := utils.Dereference(fa.X.Type())
-	fieldName := utils.FieldName(fa)
-
-	for _, p := range c.Sources {
-		if n, ok := deref.(*types.Named); ok &&
-			p.match(n) && p.FieldRE.MatchString(fieldName) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c config) IsPropagator(call *ssa.Call) bool {
-	return c.isFieldPropagator(call) || c.isTransformingPropagator(call)
-}
-
-func (c config) isFieldPropagator(call *ssa.Call) bool {
-	recv := call.Call.Signature().Recv()
-	if recv == nil {
-		return false
-	}
-
-	for _, p := range c.FieldPropagators {
-		if p.match(call) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (c config) isTransformingPropagator(call *ssa.Call) bool {
-	for _, p := range c.TransformingPropagators {
-		if !p.match(call) {
-			continue
-		}
-
-		for _, a := range call.Call.Args {
-			// TODO Handle ChangeInterface case.
-			switch t := a.(type) {
-			case *ssa.MakeInterface:
-				if c.isSource(utils.Dereference(t.X.Type())) {
-					return true
-				}
-			case *ssa.Parameter:
-				if c.isSource(utils.Dereference(t.Type())) {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
-}
-
-func (c config) sendsToIOWriter(call *ssa.Call) ssa.Node {
-	if call.Call.Signature().Params().Len() == 0 {
-		return nil
-	}
-
-	firstArg := call.Call.Signature().Params().At(0)
-	if c.PropagatorArgs.ArgumentTypeRE.MatchString(firstArg.Type().String()) {
-		if a, ok := call.Call.Args[0].(*ssa.MakeInterface); ok {
-			return a.X.(ssa.Node)
-		}
-	}
-
-	return nil
-}
-
-func (c config) isWhitelisted(pkg *types.Package) bool {
-	for _, w := range c.Whitelist {
-		if w.match(pkg) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c config) isInScope(pkg *types.Package) bool {
-	for _, s := range c.AnalysisScope {
-		if s.match(pkg) {
-			return true
-		}
-	}
-	return false
-}
-
-// A sourceMatcher defines what types are or contain sources.
-// Within a given type, specific field access can be specified as the actual source data
-// via the fieldRE.
-type sourceMatcher struct {
-	PackageRE regexp.Regexp
-	TypeRE    regexp.Regexp
-	FieldRE   regexp.Regexp
-}
-
-func (s sourceMatcher) match(n *types.Named) bool {
-	if types.IsInterface(n) {
-		// In our context, both sources and sanitizers are concrete types.
-		return false
-	}
-
-	return s.PackageRE.MatchString(n.Obj().Pkg().Path()) && s.TypeRE.MatchString(n.Obj().Name())
-}
-
-type fieldPropagatorMatcher struct {
-	Receiver   string
-	AccessorRE regexp.Regexp
-}
-
-func (f fieldPropagatorMatcher) match(call *ssa.Call) bool {
-	if call.Call.StaticCallee() == nil {
-		return false
-	}
-
-	recv := call.Call.Signature().Recv()
-	if recv == nil {
-		return false
-	}
-
-	if f.Receiver != utils.Dereference(recv.Type()).String() {
-		return false
-	}
-
-	return f.AccessorRE.MatchString(call.Call.StaticCallee().Name())
-}
-
-type transformingPropagatorMatcher struct {
-	PackageName string
-	MethodRE    regexp.Regexp
-}
-
-func (t transformingPropagatorMatcher) match(call *ssa.Call) bool {
-	if call.Call.StaticCallee() == nil ||
-		call.Call.StaticCallee().Pkg == nil ||
-		call.Call.StaticCallee().Pkg.Pkg.Path() != t.PackageName {
-		return false
-	}
-
-	return t.MethodRE.MatchString(call.Call.StaticCallee().Name())
-}
-
-type argumentPropagatorMatcher struct {
-	ArgumentTypeRE regexp.Regexp
-}
-
-type packageMatcher struct {
-	PackageNameRE regexp.Regexp
-}
-
-func (pm packageMatcher) match(pkg *types.Package) bool {
-	return pm.PackageNameRE.MatchString(pkg.Path())
-}
-
-type nameMatcher struct {
-	PackageRE regexp.Regexp
-	TypeRE    regexp.Regexp
-	MethodRE  regexp.Regexp
-}
-
-func (r nameMatcher) matchPackage(p *types.Package) bool {
-	return r.PackageRE.MatchString(p.Path())
-}
-
-func (r nameMatcher) matchMethodName(c *ssa.Call) bool {
-	if c.Call.StaticCallee() == nil || c.Call.StaticCallee().Pkg == nil {
-		return false
-	}
-
-	return r.matchPackage(c.Call.StaticCallee().Pkg.Pkg) &&
-		r.MethodRE.MatchString(c.Call.StaticCallee().Name())
-}
-
-func (r nameMatcher) matchNamedType(n *types.Named) bool {
-	if types.IsInterface(n) {
-		// In our context, both sources and sanitizers are concrete types.
-		return false
-	}
-
-	return r.PackageRE.MatchString(n.Obj().Pkg().Path()) &&
-		r.TypeRE.MatchString(n.Obj().Name())
 }
 
 var Analyzer = &analysis.Analyzer{
@@ -353,7 +90,7 @@ func newVarargs(s *ssa.Slice, sources []*source.Source) *varargs {
 	}
 }
 
-func (v *varargs) referredByCallWithPattern(patterns []nameMatcher) *ssa.Call {
+func (v *varargs) referredByCallWithPattern(patterns []config.NameMatcher) *ssa.Call {
 	if v.slice.Referrers() == nil || len(*v.slice.Referrers()) != 1 {
 		return nil
 	}
@@ -364,7 +101,7 @@ func (v *varargs) referredByCallWithPattern(patterns []nameMatcher) *ssa.Call {
 	}
 
 	for _, p := range patterns {
-		if p.matchMethodName(c) {
+		if p.MatchMethodName(c) {
 			return c
 		}
 	}
@@ -373,7 +110,7 @@ func (v *varargs) referredByCallWithPattern(patterns []nameMatcher) *ssa.Call {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	conf, err := readConfig(configFile)
+	conf, err := config.ReadConfig(configFile)
 	if err != nil {
 		return nil, err
 	}
@@ -407,14 +144,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 						// TODO  Do not hard-code the position of the argument, instead declaratively
 						//  specify the position of the propagated source.
 						// TODO  Consider turning propagators that take io.Writer into sinks.
-						if a := conf.sendsToIOWriter(v); a != nil {
+						if a := sendsToIOWriter(conf, v); a != nil {
 							sources = append(sources, source.New(a, conf))
 						} else {
 							//log.V(2).Infof("Adding source: %v %T", v.Value(), v.Value())
 							sources = append(sources, source.New(v, conf))
 						}
 
-					case conf.isSink(v):
+					case conf.IsSink(v):
 						// TODO Only variadic sink arguments are currently detected.
 						if v.Call.Signature().Variadic() && len(v.Call.Args) > 0 {
 							lastArg := v.Call.Args[len(v.Call.Args)-1]
@@ -437,32 +174,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
-var readFileOnce sync.Once
-var readConfigCached *config
-var readConfigCachedErr error
-
-func readConfig(path string) (*config, error) {
-	loadedFromCache := true
-	readFileOnce.Do(func() {
-		loadedFromCache = false
-		c := new(config)
-		bytes, err := ioutil.ReadFile(path)
-		if err != nil {
-			readConfigCachedErr = fmt.Errorf("error reading analysis config: %v", err)
-			return
-		}
-
-		if err := json.Unmarshal(bytes, c); err != nil {
-			readConfigCachedErr = err
-			return
-		}
-		readConfigCached = c
-	})
-	_ = loadedFromCache
-	return readConfigCached, readConfigCachedErr
-}
-
-func identifySources(conf *config, ssaInput *buildssa.SSA) map[*ssa.Function][]*source.Source {
+func identifySources(conf *config.Config, ssaInput *buildssa.SSA) map[*ssa.Function][]*source.Source {
 	sourceMap := make(map[*ssa.Function][]*source.Source)
 
 	for _, fn := range ssaInput.SrcFuncs {
@@ -478,12 +190,12 @@ func identifySources(conf *config, ssaInput *buildssa.SSA) map[*ssa.Function][]*
 	return sourceMap
 }
 
-func sourcesFromParams(fn *ssa.Function, conf *config) []*source.Source {
+func sourcesFromParams(fn *ssa.Function, conf *config.Config) []*source.Source {
 	var sources []*source.Source
 	for _, p := range fn.Params {
 		switch t := p.Type().(type) {
 		case *types.Pointer:
-			if n, ok := t.Elem().(*types.Named); ok && conf.isSource(n) {
+			if n, ok := t.Elem().(*types.Named); ok && conf.IsSource(n) {
 				sources = append(sources, source.New(p, conf))
 			}
 			// TODO Handle the case where sources arepassed by value: func(c sourceType)
@@ -493,14 +205,14 @@ func sourcesFromParams(fn *ssa.Function, conf *config) []*source.Source {
 	return sources
 }
 
-func sourcesFromClosure(fn *ssa.Function, conf *config) []*source.Source {
+func sourcesFromClosure(fn *ssa.Function, conf *config.Config) []*source.Source {
 	var sources []*source.Source
 	for _, p := range fn.FreeVars {
 		switch t := p.Type().(type) {
 		case *types.Pointer:
 			// FreeVars (variables from a closure) appear as double-pointers
 			// Hence, the need to dereference them recursively.
-			if s, ok := utils.Dereference(t).(*types.Named); ok && conf.isSource(s) {
+			if s, ok := utils.Dereference(t).(*types.Named); ok && conf.IsSource(s) {
 				sources = append(sources, source.New(p, conf))
 			}
 		}
@@ -508,7 +220,7 @@ func sourcesFromClosure(fn *ssa.Function, conf *config) []*source.Source {
 	return sources
 }
 
-func sourcesFromBlocks(fn *ssa.Function, conf *config) []*source.Source {
+func sourcesFromBlocks(fn *ssa.Function, conf *config.Config) []*source.Source {
 	var sources []*source.Source
 	for _, b := range fn.Blocks {
 		if b == fn.Recover {
@@ -520,14 +232,14 @@ func sourcesFromBlocks(fn *ssa.Function, conf *config) []*source.Source {
 			switch v := instr.(type) {
 			// Looking for sources of PII allocated within the body of a function.
 			case *ssa.Alloc:
-				if conf.isSource(utils.Dereference(v.Type())) {
+				if conf.IsSource(utils.Dereference(v.Type())) {
 					sources = append(sources, source.New(v, conf))
 				}
 
 				// Handling the case where PII may be in a receiver
 				// (ex. func(b *something) { log.Info(something.PII) }
 			case *ssa.FieldAddr:
-				if conf.isSource(utils.Dereference(v.Type())) {
+				if conf.IsSource(utils.Dereference(v.Type())) {
 					sources = append(sources, source.New(v, conf))
 				}
 			}
@@ -543,11 +255,17 @@ func report(pass *analysis.Pass, source *source.Source, sink ssa.Node) {
 	pass.Reportf(sink.Pos(), b.String())
 }
 
-func isTestPkg(p *types.Package) bool {
-	for _, im := range p.Imports() {
-		if im.Name() == "testing" {
-			return true
+func sendsToIOWriter(c *config.Config, call *ssa.Call) ssa.Node {
+	if call.Call.Signature().Params().Len() == 0 {
+		return nil
+	}
+
+	firstArg := call.Call.Signature().Params().At(0)
+	if c.PropagatorArgs.ArgumentTypeRE.MatchString(firstArg.Type().String()) {
+		if a, ok := call.Call.Args[0].(*ssa.MakeInterface); ok {
+			return a.X.(ssa.Node)
 		}
 	}
-	return false
+
+	return nil
 }

--- a/internal/levee.go
+++ b/internal/levee.go
@@ -28,15 +28,10 @@ import (
 	"github.com/google/go-flow-levee/internal/pkg/utils"
 )
 
-var configFile string
-
-func init() {
-	Analyzer.Flags.StringVar(&configFile, "config", "config.json", "path to analysis configuration file")
-}
-
 var Analyzer = &analysis.Analyzer{
 	Name:     "levee",
 	Run:      run,
+	Flags:    config.FlagSet,
 	Doc:      "reports attempts to source data to sinks",
 	Requires: []*analysis.Analyzer{buildssa.Analyzer},
 }
@@ -110,7 +105,7 @@ func (v *varargs) referredByCallWithPattern(patterns []config.NameMatcher) *ssa.
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	conf, err := config.ReadConfig(configFile)
+	conf, err := config.ReadConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"go/types"
 	"io/ioutil"
@@ -11,6 +12,15 @@ import (
 	"github.com/google/go-flow-levee/internal/pkg/utils"
 	"golang.org/x/tools/go/ssa"
 )
+
+
+// FlagSet should be used by analyzers to reuse -config flag.
+var FlagSet flag.FlagSet
+var configFile string
+
+func init() {
+	FlagSet.StringVar(&configFile, "config", "config.json", "path to analysis configuration file")
+}
 
 // config contains matchers and analysis scope information
 type Config struct {
@@ -276,12 +286,12 @@ var readFileOnce sync.Once
 var readConfigCached *Config
 var readConfigCachedErr error
 
-func ReadConfig(path string) (*Config, error) {
+func ReadConfig() (*Config, error) {
 	loadedFromCache := true
 	readFileOnce.Do(func() {
 		loadedFromCache = false
 		c := new(Config)
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := ioutil.ReadFile(configFile)
 		if err != nil {
 			readConfigCachedErr = fmt.Errorf("error reading analysis config: %v", err)
 			return

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
-
 // FlagSet should be used by analyzers to reuse -config flag.
 var FlagSet flag.FlagSet
 var configFile string

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -1,0 +1,307 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/types"
+	"io/ioutil"
+	"sync"
+
+	"github.com/google/go-flow-levee/internal/pkg/config/regexp"
+	"github.com/google/go-flow-levee/internal/pkg/utils"
+	"golang.org/x/tools/go/ssa"
+)
+
+// config contains matchers and analysis scope information
+type Config struct {
+	Sources                 []sourceMatcher
+	Sinks                   []NameMatcher
+	Sanitizers              []NameMatcher
+	FieldPropagators        []fieldPropagatorMatcher
+	TransformingPropagators []transformingPropagatorMatcher
+	PropagatorArgs          argumentPropagatorMatcher
+	Whitelist               []packageMatcher
+	AnalysisScope           []packageMatcher
+}
+
+// shouldSkip returns true for any function that is outside analysis scope,
+// that is whitelisted,
+// whose containing package imports "testing"
+// or whose containing package does not import any package containing a source or a sink.
+func (c Config) shouldSkip(pkg *types.Package) bool {
+	if isTestPkg(pkg) || !c.isInScope(pkg) || c.isWhitelisted(pkg) {
+		return true
+	}
+
+	// TODO Does this skip packages that own sources/sinks but don't import others?
+	for _, im := range pkg.Imports() {
+		for _, s := range c.Sinks {
+			if s.matchPackage(im) {
+				return false
+			}
+		}
+
+		for _, s := range c.Sources {
+			if s.PackageRE.MatchString(im.Path()) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func (c Config) IsSink(call *ssa.Call) bool {
+	for _, p := range c.Sinks {
+		if p.MatchMethodName(call) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c Config) IsSanitizer(call *ssa.Call) bool {
+	for _, p := range c.Sanitizers {
+		if p.MatchMethodName(call) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c Config) IsSource(t types.Type) bool {
+	n, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	for _, p := range c.Sources {
+		if p.match(n) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Config) IsSourceFieldAddr(fa *ssa.FieldAddr) bool {
+	// fa.Type() refers to the accessed field's type.
+	// fa.X.Type() refers to the surrounding struct's type.
+	deref := utils.Dereference(fa.X.Type())
+	fieldName := utils.FieldName(fa)
+
+	for _, p := range c.Sources {
+		if n, ok := deref.(*types.Named); ok &&
+			p.match(n) && p.FieldRE.MatchString(fieldName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Config) IsPropagator(call *ssa.Call) bool {
+	return c.isFieldPropagator(call) || c.isTransformingPropagator(call)
+}
+
+func (c Config) isFieldPropagator(call *ssa.Call) bool {
+	recv := call.Call.Signature().Recv()
+	if recv == nil {
+		return false
+	}
+
+	for _, p := range c.FieldPropagators {
+		if p.match(call) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c Config) isTransformingPropagator(call *ssa.Call) bool {
+	for _, p := range c.TransformingPropagators {
+		if !p.match(call) {
+			continue
+		}
+
+		for _, a := range call.Call.Args {
+			// TODO Handle ChangeInterface case.
+			switch t := a.(type) {
+			case *ssa.MakeInterface:
+				if c.IsSource(utils.Dereference(t.X.Type())) {
+					return true
+				}
+			case *ssa.Parameter:
+				if c.IsSource(utils.Dereference(t.Type())) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func (c Config) sendsToIOWriter(call *ssa.Call) ssa.Node {
+	if call.Call.Signature().Params().Len() == 0 {
+		return nil
+	}
+
+	firstArg := call.Call.Signature().Params().At(0)
+	if c.PropagatorArgs.ArgumentTypeRE.MatchString(firstArg.Type().String()) {
+		if a, ok := call.Call.Args[0].(*ssa.MakeInterface); ok {
+			return a.X.(ssa.Node)
+		}
+	}
+
+	return nil
+}
+
+func (c Config) isWhitelisted(pkg *types.Package) bool {
+	for _, w := range c.Whitelist {
+		if w.match(pkg) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Config) isInScope(pkg *types.Package) bool {
+	for _, s := range c.AnalysisScope {
+		if s.match(pkg) {
+			return true
+		}
+	}
+	return false
+}
+
+// A sourceMatcher defines what types are or contain sources.
+// Within a given type, specific field access can be specified as the actual source data
+// via the fieldRE.
+type sourceMatcher struct {
+	PackageRE regexp.Regexp
+	TypeRE    regexp.Regexp
+	FieldRE   regexp.Regexp
+}
+
+func (s sourceMatcher) match(n *types.Named) bool {
+	if types.IsInterface(n) {
+		// In our context, both sources and sanitizers are concrete types.
+		return false
+	}
+
+	return s.PackageRE.MatchString(n.Obj().Pkg().Path()) && s.TypeRE.MatchString(n.Obj().Name())
+}
+
+type fieldPropagatorMatcher struct {
+	Receiver   string
+	AccessorRE regexp.Regexp
+}
+
+func (f fieldPropagatorMatcher) match(call *ssa.Call) bool {
+	if call.Call.StaticCallee() == nil {
+		return false
+	}
+
+	recv := call.Call.Signature().Recv()
+	if recv == nil {
+		return false
+	}
+
+	if f.Receiver != utils.Dereference(recv.Type()).String() {
+		return false
+	}
+
+	return f.AccessorRE.MatchString(call.Call.StaticCallee().Name())
+}
+
+type transformingPropagatorMatcher struct {
+	PackageName string
+	MethodRE    regexp.Regexp
+}
+
+func (t transformingPropagatorMatcher) match(call *ssa.Call) bool {
+	if call.Call.StaticCallee() == nil ||
+		call.Call.StaticCallee().Pkg == nil ||
+		call.Call.StaticCallee().Pkg.Pkg.Path() != t.PackageName {
+		return false
+	}
+
+	return t.MethodRE.MatchString(call.Call.StaticCallee().Name())
+}
+
+type argumentPropagatorMatcher struct {
+	ArgumentTypeRE regexp.Regexp
+}
+
+type packageMatcher struct {
+	PackageNameRE regexp.Regexp
+}
+
+func (pm packageMatcher) match(pkg *types.Package) bool {
+	return pm.PackageNameRE.MatchString(pkg.Path())
+}
+
+type NameMatcher struct {
+	PackageRE regexp.Regexp
+	TypeRE    regexp.Regexp
+	MethodRE  regexp.Regexp
+}
+
+func (r NameMatcher) matchPackage(p *types.Package) bool {
+	return r.PackageRE.MatchString(p.Path())
+}
+
+func (r NameMatcher) MatchMethodName(c *ssa.Call) bool {
+	if c.Call.StaticCallee() == nil || c.Call.StaticCallee().Pkg == nil {
+		return false
+	}
+
+	return r.matchPackage(c.Call.StaticCallee().Pkg.Pkg) &&
+		r.MethodRE.MatchString(c.Call.StaticCallee().Name())
+}
+
+func (r NameMatcher) matchNamedType(n *types.Named) bool {
+	if types.IsInterface(n) {
+		// In our context, both sources and sanitizers are concrete types.
+		return false
+	}
+
+	return r.PackageRE.MatchString(n.Obj().Pkg().Path()) &&
+		r.TypeRE.MatchString(n.Obj().Name())
+}
+
+var readFileOnce sync.Once
+var readConfigCached *Config
+var readConfigCachedErr error
+
+func ReadConfig(path string) (*Config, error) {
+	loadedFromCache := true
+	readFileOnce.Do(func() {
+		loadedFromCache = false
+		c := new(Config)
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			readConfigCachedErr = fmt.Errorf("error reading analysis config: %v", err)
+			return
+		}
+
+		if err := json.Unmarshal(bytes, c); err != nil {
+			readConfigCachedErr = err
+			return
+		}
+		readConfigCached = c
+	})
+	_ = loadedFromCache
+	return readConfigCached, readConfigCachedErr
+}
+
+func isTestPkg(p *types.Package) bool {
+	for _, im := range p.Imports() {
+		if im.Name() == "testing" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
* Export ReadConfig
* Export Config, Config.IsSink, Config.IsSource
* Extract Config.sendsToIOWriter -> levee.sendsToIOWriter as a special case outside the scope of `Config`.
* Export NameMatcher, NameMatcher.MatchMethodName.

-----

This PR is partly in service of extracting source identification into a preliminary `Analyzer`.