### PR TITLE
Use goimports over gofmt in Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   echo "Checking gofmt..." && (
     FILES=$(find {cmd,internal} -name "*.go");
     if [[ -n $(gofmt -l ${FILES}) ]]; then
-      gofmt -d ${FILES}
+      goimports -d ${FILES}
       echo 'Please run `gofmt -w $(find {cmd,internal} -name "*.go")`.'
       false
     fi

--- a/internal/pkg/source/source_test.go
+++ b/internal/pkg/source/source_test.go
@@ -15,10 +15,11 @@
 package source
 
 import (
-	"github.com/google/go-flow-levee/internal/pkg/utils"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/google/go-flow-levee/internal/pkg/utils"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 
 import (
 	"go/types"
+
 	"golang.org/x/tools/go/ssa"
 )
 

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -16,10 +16,11 @@ package utils
 
 import (
 	"fmt"
-	"golang.org/x/tools/go/ssa"
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/ssa"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"


### PR DESCRIPTION
goimports performs import formatting in addition to formatting berformed by gofmt.