### PR TITLE
Use goimports over gofmt in Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ go:
 script:
 - go test -v ./...
 - >
-  echo "Checking gofmt..." && (
-    FILES=$(find {cmd,internal} -name "*.go");
-    if [[ -n $(gofmt -l ${FILES}) ]]; then
-      gofmt -d ${FILES}
-      echo 'Please run `gofmt -w $(find {cmd,internal} -name "*.go")`.'
+  echo "Checking goimports..." && (
+    if [[ -n $(goimports -l internal cmd) ]]; then
+      goimports -d internal cmd
+      echo 'Please run `goimports -w cmd internal`.'
       false
     fi
   )


### PR DESCRIPTION
`goimports` performs import formatting in addition to formatting performed by gofmt.