### PR TITLE
Add sourcetype analyzer.

### DIFF
--- a/cmd/sourcetype/main.go
+++ b/cmd/sourcetype/main.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/google/go-flow-levee/internal/pkg/sourcetype"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	sourcetype.Report = true
+
+	singlechecker.Main(sourcetype.Analyzer)
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -108,6 +108,20 @@ func (c Config) IsSource(t types.Type) bool {
 	return false
 }
 
+func (c Config) IsSourceField(typ types.Type, fld *types.Var) bool {
+	n, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	for _, p := range c.Sources {
+		if p.match(n) && p.FieldRE.MatchString(fld.Name()) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c Config) IsSourceFieldAddr(fa *ssa.FieldAddr) bool {
 	// fa.Type() refers to the accessed field's type.
 	// fa.X.Type() refers to the surrounding struct's type.

--- a/internal/pkg/sourcetype/analyzer.go
+++ b/internal/pkg/sourcetype/analyzer.go
@@ -1,0 +1,135 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcetype
+
+import (
+	"fmt"
+	"go/types"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-flow-levee/internal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+type typeDeclFact struct{}
+
+func (t typeDeclFact) AFact() {
+}
+
+func (t typeDeclFact) String() string {
+	return "source type"
+}
+
+type fieldDeclFact struct{}
+
+func (f fieldDeclFact) AFact() {
+}
+
+func (f fieldDeclFact) String() string {
+	return "source field"
+}
+
+type sourceClassifier struct {
+	passObjFacts []analysis.ObjectFact
+}
+
+func (s sourceClassifier) IsSource(named *types.Named) bool {
+	if named == nil {
+		return false
+	}
+
+	for _, fct := range s.passObjFacts {
+		if fct.Object == named.Obj() {
+			return true
+		}
+	}
+	return false
+}
+
+func (s sourceClassifier) IsSourceField(v *types.Var) bool {
+	for _, fct := range s.passObjFacts {
+		if fct.Object == v {
+			return true
+		}
+	}
+	return false
+}
+
+var Analyzer = &analysis.Analyzer{
+	Name:       "sourcetypes",
+	Doc:        "This analyzer identifies types.Types values which contain dataflow sources.",
+	Flags:      config.FlagSet,
+	Run:        run,
+	Requires:   []*analysis.Analyzer{buildssa.Analyzer},
+	ResultType: reflect.TypeOf(new(sourceClassifier)),
+	FactTypes:  []analysis.Fact{new(typeDeclFact), new(fieldDeclFact)},
+}
+
+var Report bool
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	ssaInput := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+	conf, err := config.ReadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Members contains all named entities
+	for _, mem := range ssaInput.Pkg.Members {
+		if ssaType, ok := mem.(*ssa.Type); ok {
+			if conf.IsSource(ssaType.Type()) {
+				pass.ExportObjectFact(ssaType.Object(), &typeDeclFact{})
+				if under, ok := ssaType.Type().Underlying().(*types.Struct); ok {
+					for i := 0; i < under.NumFields(); i++ {
+						fld := under.Field(i)
+						if conf.IsSourceField(ssaType.Type(), fld) {
+							if fld.Pkg() == pass.Pkg {
+								pass.ExportObjectFact(fld, &fieldDeclFact{})
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	classifier := &sourceClassifier{pass.AllObjectFacts()}
+	if Report {
+		makeReport(classifier, pass)
+	}
+
+	return classifier, nil
+}
+
+func makeReport(classifier *sourceClassifier, pass *analysis.Pass) {
+	// Aggregate diagnostics first in order to sort report by position.
+	var diags []analysis.Diagnostic
+	for _, objFact := range classifier.passObjFacts {
+		// A pass should only report within its package.
+		if objFact.Object.Pkg() == pass.Pkg {
+			diags = append(diags, analysis.Diagnostic{
+				Pos:     objFact.Object.Pos(),
+				Message: fmt.Sprintf("%v: %v", objFact.Fact, objFact.Object.Name()),
+			})
+		}
+	}
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Pos < diags[j].Pos })
+	for _, d := range diags {
+		pass.Reportf(d.Pos, d.Message)
+	}
+}

--- a/internal/pkg/sourcetype/analyzer.go
+++ b/internal/pkg/sourcetype/analyzer.go
@@ -14,7 +14,7 @@
 
 // Package sourcetpye handles identification of source types and fields at the type declaration.
 // This can be consumed downstream, e.g., by the sources package to identify source data at instantiation.
-// This package conserns itself with ssa.Member and types.Object, as opposed to ssa.Value and ssa.Instruction more typically used in other analysis packages.
+// This package concerns itself with ssa.Member and types.Object, as opposed to ssa.Value and ssa.Instruction more typically used in other analysis packages.
 package sourcetype
 
 import (

--- a/internal/pkg/sourcetype/analyzer_test.go
+++ b/internal/pkg/sourcetype/analyzer_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcetype
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestSourceAnalysis(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	if err := Analyzer.Flags.Set("config", testdata+"/test-config.json"); err != nil {
+		t.Error(err)
+		return
+	}
+
+	analysistest.Run(t, testdata, Analyzer, "sourcetype", "crosspkg")
+}

--- a/internal/pkg/sourcetype/testdata/src/crosspkg/test.go
+++ b/internal/pkg/sourcetype/testdata/src/crosspkg/test.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crosspkg
+
+import "sourcetype"
+
+type AliasStruct = sourcetype.Source // want AliasStruct:"source type"
+
+// TODO Consider automatic detection of the following types.
+type NamedType sourcetype.Source
+type SliceContainer []sourcetype.Source
+type ArrayContainer [5]sourcetype.Source
+type MapKeyContainer map[sourcetype.Source]interface{}
+type MapValueContainer map[string]sourcetype.Source
+
+type EmbeddedWrapper struct {
+	sourcetype.Source
+}
+
+type FieldWrapper struct {
+	s sourcetype.Source
+}

--- a/internal/pkg/sourcetype/testdata/src/sourcetype/test.go
+++ b/internal/pkg/sourcetype/testdata/src/sourcetype/test.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcetype
+
+type Source struct { // want Source:"source type"
+	Data string // want Data:"source field"
+	ID   int
+}
+
+type AliasStruct = Source // want AliasStruct:"source type"
+
+// TODO Consider automatic detection of the following types.
+type NamedType Source
+type SliceContainer []Source
+type ArrayContainer [5]Source
+type MapKeyContainer map[Source]interface{}
+type MapValueContainer map[string]Source
+
+type EmbeddedWrapper struct {
+	Source
+}
+
+type FieldWrapper struct {
+	s Source
+}

--- a/internal/pkg/sourcetype/testdata/test-config.json
+++ b/internal/pkg/sourcetype/testdata/test-config.json
@@ -1,0 +1,9 @@
+{
+  "Sources": [
+    {
+      "PackageRE": "",
+      "TypeRE": "^Source$",
+      "FieldRE": "^Data"
+    }
+  ]
+}


### PR DESCRIPTION
sourcetype.Analyzer identifies sources by type and field rather than by ssa.Value.
This allows a more concise validation of configuration, exposed in cmd/sourcetype.

This analyzer will be consumed by source.Analyzer in a future commit.

------

Since this PR had already started gotten to a comfortable size, I am holding off on consuming this analyzer's result in the `source.Analyzer`.  Doing so will require some nontrivial reorganiziation of the `source.classifier` interface to `config.Classifier`.  Additionally, a new flag will need to be introduced to control which analyzer(s) report diagnostics and which do not.