### PR TITLE
Do not mark an Alloc as a Source if it is produced by a Sanitizer

### DIFF
--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -198,7 +198,7 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 			switch v := instr.(type) {
 			// Looking for sources of PII allocated within the body of a function.
 			case *ssa.Alloc:
-				if conf.IsSource(utils.Dereference(v.Type())) {
+				if conf.IsSource(utils.Dereference(v.Type())) && !isProducedBySanitizer(v, conf) {
 					sources = append(sources, New(v, conf))
 				}
 
@@ -212,4 +212,21 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 		}
 	}
 	return sources
+}
+
+func isProducedBySanitizer(v *ssa.Alloc, conf classifier) bool {
+	for _, instr := range *v.Referrers() {
+		store, ok := instr.(*ssa.Store)
+		if !ok {
+			continue
+		}
+		call, ok := store.Val.(*ssa.Call)
+		if !ok {
+			continue
+		}
+		if conf.IsSanitizer(call) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/testdata/src/example.com/tests/dominance/tests.go
+++ b/internal/testdata/src/example.com/tests/dominance/tests.go
@@ -33,8 +33,7 @@ func TestSanitizedSourceDoesNotTriggerFindingWhenTypeAsserted(c *core.Source) {
 
 func TestSanitizedSourceDoesNotTriggerFindingWithTypedSanitizer(c core.Source) {
 	sanitized := core.SanitizeSource(c)
-	// TODO This should not trigger
-	core.Sinkf("Sanitized %v", sanitized) // want "a source has reached a sink,"
+	core.Sinkf("Sanitized %v", sanitized)
 }
 
 func TestNotGuaranteedSanitization(c *core.Source) {


### PR DESCRIPTION
This fixes a broken test in which a value return by a sanitizer with return type `Source` was marked as a source. 