### PR TITLE
Consolidate fieldPropogatorMatcher and NameMatcher

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -28,19 +28,21 @@ Sources are identified via regexp according to package, type, and field names.
 }
 ```
 
-Sinks and sanitizers are identified via regexp according to package and method name.
+Sinks, sanitizers, and some propagators (below) are identified via regexp according to package, method, and (optional) receiver name.
 
 ```json
 {
   "Sinks": [
     {
       "PackageRE": "<package path regexp>",
+      "ReceiverRE": "<type name regexp>",
       "MethodRE": "<method name regexp>"
     }
   ],
   "Sanitizers": [
     {
       "PackageRE": "<package path regexp>",
+      "ReceiverRE": "<type name regexp>",
       "MethodRE": "<method name regexp>"
     }
   ]
@@ -69,13 +71,15 @@ Argument propagators are identified via regexp matching the fully-qualified type
   "TransformingPropagators": [
     {
       "PackageRE": "<package path regexp>",
+      "ReceiverRE": "<type name regexp>",
       "MethodRE": "<method name regexp>"
     }
   ],
   "FieldPropagators": [
     {
-      "Receiver": "<fully qualified type path regexp>",
-      "AccessorRE": "<method name regexp>"
+      "PackageRE": "<package path regexp>",
+      "ReceiverRE": "<type name regexp>",
+      "MethodRE": "<method name regexp>"
     }
   ],
   "PropagatorArgs": {
@@ -83,6 +87,9 @@ Argument propagators are identified via regexp matching the fully-qualified type
   }
 }
 ```
+
+For matchers that accept a `ReceiverRE` regexp matcher, an unspecified string will match any (or no) receiver.
+To match only methods without any receiver (i.e., a top-level function), use the matcher `^$` to match an empty-string receiver name.
 
 ### Example configuration
 

--- a/configuration/example-config.json
+++ b/configuration/example-config.json
@@ -24,6 +24,7 @@
   "Sinks": [
     {
       "PackageRE": "k?log$",
+      "ReceiverRE": "",
       "MethodRE": "Info|Warning|Error|Fatal|Exit"
     }
   ],
@@ -31,6 +32,7 @@
   "TransformingPropagators": [
     {
       "PackageName": ".*proto$",
+      "ReceiverRE": "",
       "MethodRE": "^Clone$|^Marshal"
     }
   ],

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -38,9 +38,9 @@ func init() {
 // config contains matchers and analysis scope information
 type Config struct {
 	Sources                 []sourceMatcher
-	Sinks                   []NameMatcher
-	Sanitizers              []NameMatcher
-	FieldPropagators        []fieldPropagatorMatcher
+	Sinks                   []methodMatcher
+	Sanitizers              []methodMatcher
+	FieldPropagators        []methodMatcher
 	TransformingPropagators []transformingPropagatorMatcher
 	PropagatorArgs          argumentPropagatorMatcher
 	Whitelist               []packageMatcher
@@ -76,7 +76,7 @@ func (c Config) shouldSkip(pkg *types.Package) bool {
 
 func (c Config) IsSink(call *ssa.Call) bool {
 	for _, p := range c.Sinks {
-		if p.MatchMethodName(call) {
+		if p.Match(call) {
 			return true
 		}
 	}
@@ -86,7 +86,7 @@ func (c Config) IsSink(call *ssa.Call) bool {
 
 func (c Config) IsSanitizer(call *ssa.Call) bool {
 	for _, p := range c.Sanitizers {
-		if p.MatchMethodName(call) {
+		if p.Match(call) {
 			return true
 		}
 	}
@@ -152,7 +152,7 @@ func (c Config) isFieldPropagator(call *ssa.Call) bool {
 	}
 
 	for _, p := range c.FieldPropagators {
-		if p.match(call) {
+		if p.Match(call) {
 			return true
 		}
 	}
@@ -268,33 +268,38 @@ func (pm packageMatcher) match(pkg *types.Package) bool {
 	return pm.PackageNameRE.MatchString(pkg.Path())
 }
 
-type NameMatcher struct {
-	PackageRE regexp.Regexp
-	TypeRE    regexp.Regexp
-	MethodRE  regexp.Regexp
+type methodMatcher struct {
+	PackageRE  regexp.Regexp
+	ReceiverRE regexp.Regexp
+	MethodRE   regexp.Regexp
 }
 
-func (r NameMatcher) matchPackage(p *types.Package) bool {
+func (r methodMatcher) matchPackage(p *types.Package) bool {
 	return r.PackageRE.MatchString(p.Path())
 }
 
-func (r NameMatcher) MatchMethodName(c *ssa.Call) bool {
-	if c.Call.StaticCallee() == nil || c.Call.StaticCallee().Pkg == nil {
+// Match matches methods based on package, method, and receiver regexp.
+// To explicitly match a method with no receiver (i.e., a top-level function),
+// provide the ReceiverRE regexp `^$`.
+func (r methodMatcher) Match(c *ssa.Call) bool {
+	callee := c.Call.StaticCallee()
+	if callee == nil || callee.Pkg == nil {
 		return false
 	}
 
-	return r.matchPackage(c.Call.StaticCallee().Pkg.Pkg) &&
-		r.MethodRE.MatchString(c.Call.StaticCallee().Name())
-}
-
-func (r NameMatcher) matchNamedType(n *types.Named) bool {
-	if types.IsInterface(n) {
-		// In our context, both sources and sanitizers are concrete types.
+	if !r.matchPackage(callee.Pkg.Pkg) || !r.MethodRE.MatchString(callee.Name()) {
 		return false
 	}
 
-	return r.PackageRE.MatchString(n.Obj().Pkg().Path()) &&
-		r.TypeRE.MatchString(n.Obj().Name())
+	recv := c.Call.Signature().Recv()
+	var recvName string
+	if recv == nil {
+		recvName = ""
+	} else {
+		recvName = recv.Type().String()
+	}
+
+	return r.ReceiverRE.MatchString(recvName)
 }
 
 var readFileOnce sync.Once

--- a/internal/testdata/test-config.json
+++ b/internal/testdata/test-config.json
@@ -20,8 +20,9 @@
   ],
   "FieldPropagators": [
     {
-      "Receiver": "example.com/core.Source",
-      "AccessorRE": "^GetData$",
+      "PackageRE": "^example.com/core$",
+      "ReceiverRE": "Source",
+      "MethodRE": "^GetData$",
       "TODO": "Make this explicit configuration unnecessary."
     }
   ],


### PR DESCRIPTION
* methodMatcher subsumes both, matching package, receiver, and method names.

------

I noticed that `NameMatcher.TypeRE` was unused -- its only use being in a function that was nowhere called.  

Judging by the dead `NameMatcher.matchNamedType` method, this was possibly due to a divergence in type between `fieldPropogatorMatcher` and `NameMatcher`.  I can see no reason for the underlying implementation of these to be kept separate, and so have unified them here.

This could also apply to the distinction between `FieldPropagator` and `TranformingPropagator`.  We should consider unifying both the implementation and the configuration of these to simply be `Propogator` in the future.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR