### PR TITLE
WIP: Detect sources in slices

### DIFF
--- a/internal/testdata/src/example.com/tests/collections/tests.go
+++ b/internal/testdata/src/example.com/tests/collections/tests.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,28 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package collections
 
 import (
-	"testing"
-
-	"golang.org/x/tools/go/analysis/analysistest"
+	"example.com/core"
 )
 
-var patterns = []string{
-	"example.com/tests/arguments",
-	"example.com/tests/declarations",
-	"example.com/tests/dominance",
-	"example.com/tests/fields",
-	"example.com/tests/receivers",
-	"example.com/tests/sinks",
-	"example.com/tests/collections",
-}
-
-func TestLevee(t *testing.T) {
-	dir := analysistest.TestData()
-	if err := Analyzer.Flags.Set("config", dir+"/test-config.json"); err != nil {
-		t.Error(err)
-	}
-	analysistest.Run(t, dir, Analyzer, patterns...)
+func TestSlices(s core.Source) {
+	slice := []core.Source{s}
+	core.Sink(slice)                   // want "a source has reached a sink"
+	core.Sink([]core.Source{s})        // want "a source has reached a sink"
+	core.Sink([]interface{}{s})        // want "a source has reached a sink"
+	core.Sink([]interface{}{0, "", s}) // want "a source has reached a sink"
 }

--- a/internal/testdata/src/example.com/tests/sinks/tests.go
+++ b/internal/testdata/src/example.com/tests/sinks/tests.go
@@ -27,7 +27,6 @@ func TestSinks(s core.Source, writer io.Writer) {
 	core.OneArgSink(s)            // TODO want "a source has reached a sink"
 
 	core.Sink([]interface{}{s, s, s}...) // TODO want "a source has reached a sink"
-	core.Sink([]interface{}{s, s, s})    // TODO want "a source has reached a sink"
 }
 
 func TestSinksWithRef(s *core.Source, writer io.Writer) {
@@ -37,7 +36,6 @@ func TestSinksWithRef(s *core.Source, writer io.Writer) {
 	core.OneArgSink(s)            // TODO want "a source has reached a sink"
 
 	core.Sink([]interface{}{s, s, s}...) // TODO want "a source has reached a sink"
-	core.Sink([]interface{}{s, s, s})    // TODO want "a source has reached a sink"
 }
 
 func TestSinksInnocuous(innoc core.Innocuous, writer io.Writer) {


### PR DESCRIPTION
This is (as will be obvious upon reading the code) a work in progress. I am not looking for comments on the code itself.

I am opening a PR to discuss the general approach, and to get some thoughts on how to integrate this with the rest of the code. I think the most natural place to put this new code would be in `source.go`, but the approach is quite different. In short, I am using the names of SSA variables in a block to create a graph (e.g., the SSA instruction `*t2 = t3` becomes an edge `t3 -> t2`) which is then used to check reachability of sinks from sources. As a disclaimer, the documentation for the SSA package seems to suggest that using the names may not be reliable.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR