### PR TITLE
Handle slices

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -84,6 +84,16 @@ func (c Config) IsSink(call *ssa.Call) bool {
 	return false
 }
 
+func (c Config) IsSinkFunction(f *ssa.Function) bool {
+	for _, p := range c.Sinks {
+		if p.MethodRE.MatchString(f.Name()) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (c Config) IsSanitizer(call *ssa.Call) bool {
 	for _, p := range c.Sanitizers {
 		if p.Match(call) {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -31,6 +31,7 @@ type classifier interface {
 	IsSanitizer(*ssa.Call) bool
 	IsPropagator(*ssa.Call) bool
 	IsSourceFieldAddr(*ssa.FieldAddr) bool
+	IsSinkFunction(fn *ssa.Function) bool
 }
 
 // Source represents a Source in an SSA call tree.
@@ -68,15 +69,22 @@ func (a *Source) dfs(n ssa.Node) {
 	a.preOrder = append(a.preOrder, n)
 	a.marked[n.(ssa.Node)] = true
 
-	if n.Referrers() == nil {
-		return
+	if n.Referrers() != nil {
+		a.visitReferrers(n.Referrers())
 	}
 
-	for _, r := range *n.Referrers() {
+	var operands []*ssa.Value
+	operands = n.Operands(operands)
+	if operands != nil {
+		a.visitOperands(operands)
+	}
+}
+
+func (a *Source) visitReferrers(referrers *[]ssa.Instruction) {
+	for _, r := range *referrers {
 		if a.marked[r.(ssa.Node)] {
 			continue
 		}
-
 		switch v := r.(type) {
 		case *ssa.Call:
 			// This is to avoid attaching calls where the source is the receiver, ex:
@@ -84,7 +92,6 @@ func (a *Source) dfs(n ssa.Node) {
 			if v.Call.Signature().Recv() != nil {
 				continue
 			}
-
 			if a.config.IsSanitizer(v) {
 				a.sanitizers = append(a.sanitizers, &sanitizer.Sanitizer{Call: v})
 			}
@@ -93,8 +100,17 @@ func (a *Source) dfs(n ssa.Node) {
 				continue
 			}
 		}
-
 		a.dfs(r.(ssa.Node))
+	}
+}
+
+func (a *Source) visitOperands(operands []*ssa.Value) {
+	for _, o := range operands {
+		n, ok := (*o).(ssa.Node)
+		if !ok || a.marked[n] {
+			continue
+		}
+		a.dfs(n)
 	}
 }
 
@@ -148,6 +164,11 @@ func identify(conf classifier, ssaInput *buildssa.SSA) map[*ssa.Function][]*Sour
 	sourceMap := make(map[*ssa.Function][]*Source)
 
 	for _, fn := range ssaInput.SrcFuncs {
+		// no need to analyze the body of sinks
+		if conf.IsSinkFunction(fn) {
+			continue
+		}
+
 		var sources []*Source
 		sources = append(sources, sourcesFromParams(fn, conf)...)
 		sources = append(sources, sourcesFromClosure(fn, conf)...)

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -110,7 +110,10 @@ func (a *Source) visitOperands(operands []*ssa.Value) {
 		if !ok || a.marked[n] {
 			continue
 		}
-		a.dfs(n)
+		al, ok := (*o).(*ssa.Alloc)
+		if !ok || al.Comment == "slicelit" || a.config.IsSource(al.Type()) {
+			a.dfs(n)
+		}
 	}
 }
 

--- a/internal/pkg/source/source_test.go
+++ b/internal/pkg/source/source_test.go
@@ -32,6 +32,7 @@ type testConfig struct {
 	propagatorsPattern string
 	fieldsPattern      string
 	sanitizerPattern   string
+	sinkPattern        string
 }
 
 func (c *testConfig) IsSource(t types.Type) bool {
@@ -60,6 +61,11 @@ func (c *testConfig) IsSourceFieldAddr(field *ssa.FieldAddr) bool {
 	return match
 }
 
+func (c *testConfig) IsSinkFunction(f *ssa.Function) bool {
+	match, _ := regexp.MatchString(c.sinkPattern, f.Name())
+	return match
+}
+
 var testAnalyzer = &analysis.Analyzer{
 	Name:     "source",
 	Run:      runTest,
@@ -74,6 +80,7 @@ func runTest(pass *analysis.Pass) (interface{}, error) {
 		propagatorsPattern: "propagator",
 		sanitizerPattern:   "sanitizer",
 		fieldsPattern:      "name",
+		sinkPattern:        "sink",
 	}
 
 	sm := identify(config, in)

--- a/internal/pkg/varargs/varargs_test.go
+++ b/internal/pkg/varargs/varargs_test.go
@@ -49,6 +49,10 @@ func (c *testConfig) IsSourceFieldAddr(field *ssa.FieldAddr) bool {
 	return false
 }
 
+func (c *testConfig) IsSinkFunction(f *ssa.Function) bool {
+	return false
+}
+
 type analyzerResult struct {
 	allocations []*ssa.Alloc
 	calls       []*ssa.Call

--- a/internal/testdata/src/example.com/tests/collections/tests.go
+++ b/internal/testdata/src/example.com/tests/collections/tests.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,28 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package collections
 
 import (
-	"testing"
-
-	"golang.org/x/tools/go/analysis/analysistest"
+	"example.com/core"
 )
 
-var patterns = []string{
-	"example.com/tests/arguments",
-	"example.com/tests/collections",
-	"example.com/tests/declarations",
-	"example.com/tests/dominance",
-	"example.com/tests/fields",
-	"example.com/tests/receivers",
-	"example.com/tests/sinks",
-}
-
-func TestLevee(t *testing.T) {
-	dir := analysistest.TestData()
-	if err := Analyzer.Flags.Set("config", dir+"/test-config.json"); err != nil {
-		t.Error(err)
-	}
-	analysistest.Run(t, dir, Analyzer, patterns...)
+func TestSlices(s core.Source) {
+	slice := []core.Source{s}
+	core.Sink(slice)                   // want "a source has reached a sink"
+	core.Sink([]core.Source{s})        // want "a source has reached a sink"
+	core.Sink([]interface{}{s})        // want "a source has reached a sink"
+	core.Sink([]interface{}{0, "", s}) // want "a source has reached a sink"
 }

--- a/internal/testdata/src/example.com/tests/collections/tests.go
+++ b/internal/testdata/src/example.com/tests/collections/tests.go
@@ -20,8 +20,9 @@ import (
 
 func TestSlices(s core.Source) {
 	slice := []core.Source{s}
-	core.Sink(slice)                   // want "a source has reached a sink"
-	core.Sink([]core.Source{s})        // want "a source has reached a sink"
-	core.Sink([]interface{}{s})        // want "a source has reached a sink"
-	core.Sink([]interface{}{0, "", s}) // want "a source has reached a sink"
+	core.Sink(slice)                      // want "a source has reached a sink"
+	core.Sink([]core.Source{s})           // want "a source has reached a sink"
+	core.Sink([]interface{}{s})           // want "a source has reached a sink"
+	core.Sink([]interface{}{0, "", s})    // want "a source has reached a sink"
+	core.Sink([]interface{}{0, "", s}...) // TODO want "a source has reached a sink"
 }

--- a/internal/testdata/src/example.com/tests/collections/tests.go
+++ b/internal/testdata/src/example.com/tests/collections/tests.go
@@ -24,5 +24,5 @@ func TestSlices(s core.Source) {
 	core.Sink([]core.Source{s})           // want "a source has reached a sink"
 	core.Sink([]interface{}{s})           // want "a source has reached a sink"
 	core.Sink([]interface{}{0, "", s})    // want "a source has reached a sink"
-	core.Sink([]interface{}{0, "", s}...) // TODO want "a source has reached a sink"
+	core.Sink([]interface{}{0, "", s}...) // want "a source has reached a sink"
 }

--- a/internal/testdata/src/example.com/tests/sinks/tests.go
+++ b/internal/testdata/src/example.com/tests/sinks/tests.go
@@ -25,9 +25,6 @@ func TestSinks(s core.Source, writer io.Writer) {
 	core.Sinkf("a source: %v", s) // want "a source has reached a sink"
 	core.FSinkf(writer, s)        // want "a source has reached a sink"
 	core.OneArgSink(s)            // want "a source has reached a sink"
-
-	core.Sink([]interface{}{s, s, s}...) // want "a source has reached a sink"
-	core.Sink([]interface{}{s, s, s})    // TODO want "a source has reached a sink"
 }
 
 func TestSinksWithRef(s *core.Source, writer io.Writer) {
@@ -35,9 +32,6 @@ func TestSinksWithRef(s *core.Source, writer io.Writer) {
 	core.Sinkf("a source: %v", s) // want "a source has reached a sink"
 	core.FSinkf(writer, s)        // want "a source has reached a sink"
 	core.OneArgSink(s)            // want "a source has reached a sink"
-
-	core.Sink([]interface{}{s, s, s}...) // want "a source has reached a sink"
-	core.Sink([]interface{}{s, s, s})    // TODO want "a source has reached a sink"
 }
 
 func TestSinksInnocuous(innoc core.Innocuous, writer io.Writer) {

--- a/internal/testdata/test-config.json
+++ b/internal/testdata/test-config.json
@@ -9,7 +9,7 @@
   "Sinks": [
     {
       "PackageRE": "^example.com/core$",
-      "MethodRE": "Sink"
+      "MethodRE": "Sinkf?$"
     }
   ],
   "Sanitizers": [


### PR DESCRIPTION
This PR adds support for propagating taint to slices in order to report "a source has reached a sink" when a slice containing a tainted value gets sinked.

In order to propagate the taint to slices, we need to DFS into the operands of nodes.

I have also modified the source analyzer to not visit sink functions. This was required to prevent a spurious diagnostic in the "domination" test.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR (N/A)