### PR TITLE
Introduce minimal field propagator analyzer

### DIFF
--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -62,16 +62,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	ssaProg := ssaInput.Pkg.Prog
 	for _, mem := range ssaInput.Pkg.Members {
-		if ssaType, ok := mem.(*ssa.Type); ok && conf.IsSource(ssaType.Type()) {
-			methods := ssaProg.MethodSets.MethodSet(ssaType.Type())
-			for i := 0; i < methods.Len(); i++ {
-				meth := ssaProg.MethodValue(methods.At(i))
-				// Function does not return anything
-				if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
-					continue
-				}
-				analyzeBlocks(pass, conf, meth)
+		ssaType, ok := mem.(*ssa.Type)
+		if !ok || !conf.IsSource(ssaType.Type()) {
+			continue
+		}
+		methods := ssaProg.MethodSets.MethodSet(ssaType.Type())
+		for i := 0; i < methods.Len(); i++ {
+			meth := ssaProg.MethodValue(methods.At(i))
+			// Function does not return anything
+			if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
+				continue
 			}
+			analyzeBlocks(pass, conf, meth)
 		}
 	}
 
@@ -84,21 +86,28 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 func analyzeBlocks(pass *analysis.Pass, conf *config.Config, meth *ssa.Function) {
 	for _, b := range meth.Blocks {
+		if len(b.Instrs) == 0 {
+			continue
+		}
 		lastInstr := b.Instrs[len(b.Instrs)-1]
 		ret, ok := lastInstr.(*ssa.Return)
 		if !ok {
 			continue
 		}
-		for _, r := range ret.Results {
-			fa, ok := fieldAddr(r)
-			if !ok {
-				continue
-			}
-			if conf.IsSourceFieldAddr(fa) {
-				pass.ExportObjectFact(meth.Object(), &isFieldPropagator{})
-				if reporting {
-					pass.Reportf(meth.Pos(), "field propagator identified")
-				}
+		analyzeResults(pass, conf, meth, ret.Results)
+	}
+}
+
+func analyzeResults(pass *analysis.Pass, conf *config.Config, meth *ssa.Function, results []ssa.Value) {
+	for _, r := range results {
+		fa, ok := fieldAddr(r)
+		if !ok {
+			continue
+		}
+		if conf.IsSourceFieldAddr(fa) {
+			pass.ExportObjectFact(meth.Object(), &isFieldPropagator{})
+			if reporting {
+				pass.Reportf(meth.Pos(), "field propagator identified")
 			}
 		}
 	}

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -37,14 +37,11 @@ func (i isFieldPropagator) String() string {
 	return "field propagator identified"
 }
 
-// For testing purposes.
-// Specifically, this makes the analyzer report field propagators it finds,
-// which allows us to use analysistest "want" expectations.
-var reporting bool
-
 var Analyzer = &analysis.Analyzer{
-	Name:       "fieldpropagator",
-	Doc:        "This analyzer identifies field propagators.",
+	Name: "fieldpropagator",
+	Doc: `This analyzer identifies field propagators.
+
+A field propagator is a function that returns a source field.`,
 	Flags:      config.FlagSet,
 	Run:        run,
 	Requires:   []*analysis.Analyzer{buildssa.Analyzer},
@@ -106,9 +103,6 @@ func analyzeResults(pass *analysis.Pass, conf *config.Config, meth *ssa.Function
 		}
 		if conf.IsSourceFieldAddr(fa) {
 			pass.ExportObjectFact(meth.Object(), &isFieldPropagator{})
-			if reporting {
-				pass.Reportf(meth.Pos(), "field propagator identified")
-			}
 		}
 	}
 }

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -1,0 +1,114 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fieldpropagator
+
+import (
+	"go/types"
+	"reflect"
+
+	"github.com/google/go-flow-levee/internal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+// ResultType is a map telling whether an object (really a function) is a field propagator.
+type ResultType = map[types.Object]bool
+
+type isFieldPropagator struct{}
+
+func (i isFieldPropagator) AFact() {}
+
+func (i isFieldPropagator) String() string {
+	return "field propagator identified"
+}
+
+// For testing purposes.
+// Specifically, this makes the analyzer report field propagators it finds,
+// which allows us to use analysistest "want" expectations.
+var reporting bool
+
+var Analyzer = &analysis.Analyzer{
+	Name:       "fieldpropagator",
+	Doc:        "This analyzer identifies field propagators.",
+	Flags:      config.FlagSet,
+	Run:        run,
+	Requires:   []*analysis.Analyzer{buildssa.Analyzer},
+	ResultType: reflect.TypeOf(new(ResultType)).Elem(),
+	FactTypes:  []analysis.Fact{new(isFieldPropagator)},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	ssaInput := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+
+	conf, err := config.ReadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	ssaProg := ssaInput.Pkg.Prog
+	for _, mem := range ssaInput.Pkg.Members {
+		if ssaType, ok := mem.(*ssa.Type); ok && conf.IsSource(ssaType.Type()) {
+			methods := ssaProg.MethodSets.MethodSet(ssaType.Type())
+			for i := 0; i < methods.Len(); i++ {
+				meth := ssaProg.MethodValue(methods.At(i))
+
+				// Function does not return anything
+				if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
+					continue
+				}
+
+				var lastBlock *ssa.BasicBlock
+				for _, b := range meth.Blocks {
+					if len(b.Succs) == 0 {
+						lastBlock = b
+					}
+				}
+				if lastBlock == nil {
+					continue
+				}
+
+				lastInstr := lastBlock.Instrs[len(lastBlock.Instrs)-1]
+				ret, isRet := lastInstr.(*ssa.Return)
+				if !isRet {
+					continue
+				}
+
+				for _, r := range ret.Results {
+					unOp, ok := r.(*ssa.UnOp)
+					if !ok {
+						continue
+					}
+					fa, isFA := unOp.X.(*ssa.FieldAddr)
+					if !isFA {
+						continue
+					}
+					if conf.IsSourceFieldAddr(fa) {
+						pass.ExportObjectFact(meth.Object(), &isFieldPropagator{})
+						if reporting {
+							pass.Reportf(meth.Pos(), "field propagator identified")
+						}
+					}
+				}
+			}
+		}
+	}
+
+	isFieldPropagator := map[types.Object]bool{}
+	for _, f := range pass.AllObjectFacts() {
+		isFieldPropagator[f.Object] = true
+	}
+	return isFieldPropagator, nil
+}

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -85,8 +85,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func analyzeBlocks(pass *analysis.Pass, conf *config.Config, meth *ssa.Function) {
 	for _, b := range meth.Blocks {
 		lastInstr := b.Instrs[len(b.Instrs)-1]
-		ret, isRet := lastInstr.(*ssa.Return)
-		if !isRet {
+		ret, ok := lastInstr.(*ssa.Return)
+		if !ok {
 			continue
 		}
 		for _, r := range ret.Results {

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -69,10 +69,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		methods := ssaProg.MethodSets.MethodSet(ssaType.Type())
 		for i := 0; i < methods.Len(); i++ {
 			meth := ssaProg.MethodValue(methods.At(i))
-			// Function does not return anything
-			if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
-				continue
-			}
 			analyzeBlocks(pass, conf, meth)
 		}
 	}
@@ -85,6 +81,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func analyzeBlocks(pass *analysis.Pass, conf *config.Config, meth *ssa.Function) {
+	// Function does not return anything
+	if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
+		return
+	}
 	for _, b := range meth.Blocks {
 		if len(b.Instrs) == 0 {
 			continue

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package fieldpropagator implements identification of field propagators.
+// A field propagator is a function that returns a source field.
 package fieldpropagator
 
 import (

--- a/internal/pkg/fieldpropagator/analyzer_test.go
+++ b/internal/pkg/fieldpropagator/analyzer_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fieldpropagator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-flow-levee/internal/pkg/config"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestFieldPropagatorAnalysis(t *testing.T) {
+	testdata := analysistest.TestData()
+	if err := config.FlagSet.Set("config", filepath.Join(testdata, "test-config.json")); err != nil {
+		t.Error(err)
+	}
+	analysistest.Run(t, testdata, Analyzer, "source", "test")
+}

--- a/internal/pkg/fieldpropagator/testdata/src/source/test.go
+++ b/internal/pkg/fieldpropagator/testdata/src/source/test.go
@@ -15,12 +15,38 @@
 package source
 
 type Source struct {
-	data string
-	id   int
+	data    string
+	dataPtr *string
+	id      int
 }
 
 func (s Source) Data() string { // want Data:"field propagator identified"
 	return s.data
+}
+
+func (s Source) DataRef() *string { // want DataRef:"field propagator identified"
+	return &s.data
+}
+
+func (s Source) DataPtr() *string { // want DataPtr:"field propagator identified"
+	return s.dataPtr
+}
+
+func (s Source) DataDeref() string { // want DataDeref:"field propagator identified"
+	return *s.dataPtr
+}
+
+var isAdmin bool
+
+func (s Source) MaybeData() string { // want MaybeData:"field propagator identified"
+	if isAdmin {
+		return s.data
+	}
+	return "<redacted>"
+}
+
+func (s Source) TryGetData() (string, error) { // want TryGetData:"field propagator identified"
+	return s.data, nil
 }
 
 func New(data string) Source {

--- a/internal/pkg/fieldpropagator/testdata/src/source/test.go
+++ b/internal/pkg/fieldpropagator/testdata/src/source/test.go
@@ -20,6 +20,10 @@ type Source struct {
 	id      int
 }
 
+func (s Source) ID() int {
+	return s.id
+}
+
 func (s Source) Data() string { // want Data:"field propagator identified"
 	return s.data
 }

--- a/internal/pkg/fieldpropagator/testdata/src/source/test.go
+++ b/internal/pkg/fieldpropagator/testdata/src/source/test.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+type Source struct {
+	data string
+	id   int
+}
+
+func (s Source) Data() string { // want Data:"field propagator identified"
+	return s.data
+}
+
+func New(data string) Source {
+	return Source{data: data, id: 0}
+}

--- a/internal/pkg/fieldpropagator/testdata/src/source/test.go
+++ b/internal/pkg/fieldpropagator/testdata/src/source/test.go
@@ -56,3 +56,11 @@ func (s Source) TryGetData() (string, error) { // want TryGetData:"field propaga
 func New(data string) Source {
 	return Source{data: data, id: 0}
 }
+
+type NotSource struct {
+	data string
+}
+
+func (n NotSource) Data() string {
+	return n.data
+}

--- a/internal/pkg/fieldpropagator/testdata/src/test/test.go
+++ b/internal/pkg/fieldpropagator/testdata/src/test/test.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import "source"
+
+func Test() {
+	s := source.New("secret")
+	d := s.Data()
+	_ = d
+}

--- a/internal/pkg/fieldpropagator/testdata/test-config.json
+++ b/internal/pkg/fieldpropagator/testdata/test-config.json
@@ -1,0 +1,9 @@
+{
+  "Sources": [
+    {
+      "PackageRE": "source",
+      "TypeRE": "^Source$",
+      "FieldRE": "^data"
+    }
+  ]
+}


### PR DESCRIPTION
Introduces a (minimal) new analyzer for identifying **field propagators** automatically.

By **field propagators**, I mean any function on a `Source` type that returns a value tainted by a `Source` field. At present the code does not actually cover *all* such cases, but it does the cover the cases that we are currently testing for. More cases will be added in a future PR, and the code will be extended to capture those as well.

Integration with the main analyzer (levee) will come in a future PR, along with additional tests.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR (N/A)
