### PR TITLE
Detect test patterns automatically

### DIFF
--- a/internal/levee_test.go
+++ b/internal/levee_test.go
@@ -15,24 +15,30 @@
 package internal
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-var patterns = []string{
-	"example.com/tests/arguments",
-	"example.com/tests/declarations",
-	"example.com/tests/dominance",
-	"example.com/tests/fields",
-	"example.com/tests/receivers",
-	"example.com/tests/sinks",
-}
-
 func TestLevee(t *testing.T) {
-	dir := analysistest.TestData()
-	if err := Analyzer.Flags.Set("config", dir+"/test-config.json"); err != nil {
+	dataDir := analysistest.TestData()
+	testsDir := filepath.Join(dataDir, "src/example.com/tests")
+	patterns := findTestPatterns(t, testsDir)
+	if err := Analyzer.Flags.Set("config", dataDir+"/test-config.json"); err != nil {
 		t.Error(err)
 	}
-	analysistest.Run(t, dir, Analyzer, patterns...)
+	analysistest.Run(t, dataDir, Analyzer, patterns...)
+}
+
+func findTestPatterns(t *testing.T, testsDir string) (patterns []string) {
+	files, err := ioutil.ReadDir(testsDir)
+	if err != nil {
+		t.Fatalf("Failed to read tests dir (%s): %v", testsDir, err)
+	}
+	for _, f := range files {
+		patterns = append(patterns, filepath.Join(testsDir, f.Name()))
+	}
+	return
 }

--- a/internal/levee_test.go
+++ b/internal/levee_test.go
@@ -33,6 +33,7 @@ func TestLevee(t *testing.T) {
 }
 
 func findTestPatterns(t *testing.T, testsDir string) (patterns []string) {
+	t.Helper()
 	files, err := ioutil.ReadDir(testsDir)
 	if err != nil {
 		t.Fatalf("Failed to read tests dir (%s): %v", testsDir, err)


### PR DESCRIPTION
On a number of occasions, I've added new tests under `testdata/src/example.com/tests`, ran the tests for levee using `go test levee_test.go`, and been surprised to find that the tests were already passing. This is because the new tests weren't actually being run. To run the new tests, the path to the directory has to be added to the `patterns` slice. I feel like this should be handled automatically, hence this PR.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR (N/A)