### PR TITLE
Introduce debugging enchantments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /.idea
 
 # Debugging output
-internal/debug_output
+output

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Default ignored files
 /.idea
+
+# Debugging output
+internal/debug_output

--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ See [design/](design/README.md).
 
 See [configuration/](configuration/README.md) for configuration details.
 
+### Debugging
+
+The main analyzer depends heavily on the SSA package. Being able to read the SSA code and visualize its graph can be very useful for debugging. In order to generate the SSA code and DOT (graphviz) source for every function in a test, run `go test levee_test.go -debug`. Results are written to the `output` directory. You can generate a PDF from the DOT source using `dot -Tpdf <file> -o "$(basename <file> .dot).pdf"`.
+
+Currently, debugging is only supported for `levee_test.go`. In order to add support for debugging in a new test, first add a debugging flag:
+```go
+var debugging bool
+
+func init() {
+	flag.BoolVar(&debugging, "debug", false, "run the debug analyzer")
+}
+```
+Then add `debug.Analyzer` as a dependency of the analyzer being tested:
+```go
+if debugging {
+	Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
+}
+```
+
 ## Source Code Headers
 
 Every file containing source code must include copyright and license

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ In the `dot` output:
 * A **red** edge points to a **Referrer** of an `ssa.Node`
 * An **orange** edges points to an **Operand** of an `ssa.Node`
 * **Diamond**-shaped nodes represent `ssa.Node`s that are both `ssa.Instruction`s and `ssa.Value`s
-* **Square**-shaped node reprsent `ssa.Node`s that are only `ssa.Instruction`s
+* **Square**-shaped node represent `ssa.Node`s that are only `ssa.Instruction`s
+* **Ellipse**-shaped nodes that are either only `ssa.Value`s, or are `ssa.Member`s.
 
 ## Source Code Headers
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,20 @@ The main analyzer depends heavily on the SSA package. Being able to read the SSA
 
 Currently, debugging is only supported for `levee_test.go`. In order to add support for debugging in a new test, first add a debugging flag:
 ```go
-var debugging bool
-
-func init() {
-	flag.BoolVar(&debugging, "debug", false, "run the debug analyzer")
-}
+var debugging bool = flag.Bool("debug", false, "run the debug analyzer")
 ```
 Then add `debug.Analyzer` as a dependency of the analyzer being tested:
 ```go
-if debugging {
+if *debugging {
 	Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
 }
 ```
+
+In the `dot` output:
+* A **red** edge points to a **Referrer** of an `ssa.Node`
+* An **orange** edges points to an **Operand** of an `ssa.Node`
+* **Diamond**-shaped nodes represent `ssa.Node`s that are both `ssa.Instruction`s and `ssa.Value`s
+* **Square**-shaped node reprsent `ssa.Node`s that are only `ssa.Instruction`s
 
 ## Source Code Headers
 

--- a/internal/levee_test.go
+++ b/internal/levee_test.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"testing"
 
+	"github.com/google/go-flow-levee/internal/pkg/debug"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
@@ -29,10 +30,18 @@ var patterns = []string{
 	"example.com/tests/sinks",
 }
 
+var debugging bool
+
 func TestLevee(t *testing.T) {
 	dir := analysistest.TestData()
 	if err := Analyzer.Flags.Set("config", dir+"/test-config.json"); err != nil {
 		t.Error(err)
+	}
+	if debugging {
+		analysistest.Run(t, dir, debug.Analyzer, patterns...)
+		// return without running the actual Analyzer since the above run
+		// does not produce any diagnostics, so the output will be very cluttered
+		return
 	}
 	analysistest.Run(t, dir, Analyzer, patterns...)
 }

--- a/internal/levee_test.go
+++ b/internal/levee_test.go
@@ -24,11 +24,7 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-var debugging bool
-
-func init() {
-	flag.BoolVar(&debugging, "debug", false, "run the debug analyzer")
-}
+var debugging *bool = flag.Bool("debug", false, "run the debug analyzer")
 
 func TestLevee(t *testing.T) {
 	dataDir := analysistest.TestData()
@@ -37,7 +33,7 @@ func TestLevee(t *testing.T) {
 	}
 	testsDir := filepath.Join(dataDir, "src/example.com/tests")
 	patterns := findTestPatterns(t, testsDir)
-	if debugging {
+	if *debugging {
 		Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
 	}
 	analysistest.Run(t, dataDir, Analyzer, patterns...)

--- a/internal/levee_test.go
+++ b/internal/levee_test.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/google/go-flow-levee/internal/pkg/debug"
@@ -32,16 +33,17 @@ var patterns = []string{
 
 var debugging bool
 
+func init() {
+	flag.BoolVar(&debugging, "debug", false, "run the debug analyzer")
+}
+
 func TestLevee(t *testing.T) {
 	dir := analysistest.TestData()
 	if err := Analyzer.Flags.Set("config", dir+"/test-config.json"); err != nil {
 		t.Error(err)
 	}
 	if debugging {
-		analysistest.Run(t, dir, debug.Analyzer, patterns...)
-		// return without running the actual Analyzer since the above run
-		// does not produce any diagnostics, so the output will be very cluttered
-		return
+		Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
 	}
 	analysistest.Run(t, dir, Analyzer, patterns...)
 }

--- a/internal/pkg/debug/debug.go
+++ b/internal/pkg/debug/debug.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package debug
 
 import (

--- a/internal/pkg/debug/debug.go
+++ b/internal/pkg/debug/debug.go
@@ -1,0 +1,26 @@
+package debug
+
+import (
+	"github.com/google/go-flow-levee/internal/pkg/debug/dump"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "debug",
+	Run:      run,
+	Doc:      "dumps SSA and DOT source for every function",
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	ssaInput := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+
+	for _, f := range ssaInput.SrcFuncs {
+		pkgName := f.Pkg.Pkg.Name()
+		dump.SSA(pkgName, f)
+		dump.DOT(pkgName, f)
+	}
+
+	return nil, nil
+}

--- a/internal/pkg/debug/dump/dump.go
+++ b/internal/pkg/debug/dump/dump.go
@@ -1,0 +1,39 @@
+package dump
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-flow-levee/internal/pkg/debug/render"
+	"golang.org/x/tools/go/ssa"
+)
+
+// SSA dumps a function's SSA to a file.
+func SSA(fileName string, f *ssa.Function) {
+	saveSSA(fileName, f.Name(), render.SSA(f))
+}
+
+func saveSSA(fileName, funcName, s string) {
+	save(fileName, funcName, s, "ssa")
+}
+
+// DOT dumps DOT source representing the function's SSA graph to a file.
+func DOT(fileName string, f *ssa.Function) {
+	saveDOT(fileName, f.Name(), render.DOT(f))
+}
+
+func saveDOT(fileName, funcName, s string) {
+	save(fileName, funcName, s, "dot")
+}
+
+func save(fileName, funcName, s, ending string) {
+	outName := strings.TrimSuffix(fileName, ".go") + "_" + funcName + "." + ending
+	ioutil.WriteFile(filepath.Join(ensureExists("debug_output"), outName), []byte(s), 0666)
+}
+
+func ensureExists(dirName string) string {
+	os.MkdirAll(dirName, 0755)
+	return dirName
+}

--- a/internal/pkg/debug/dump/dump.go
+++ b/internal/pkg/debug/dump/dump.go
@@ -16,6 +16,7 @@
 package dump
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -37,8 +38,12 @@ func DOT(fileName string, f *ssa.Function) {
 }
 
 func save(fileName, funcName, s, ending string) {
-	outFile := strings.TrimSuffix(fileName, ".go") + "_" + funcName + "." + ending
-	ioutil.WriteFile(filepath.Join(outDir(), outFile), []byte(s), 0666)
+	baseName := strings.TrimSuffix(fileName, ".go")
+	outFile := fmt.Sprintf("%s_%s.%s", baseName, funcName, ending)
+	err := ioutil.WriteFile(filepath.Join(outDir(), outFile), []byte(s), 0666)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not write to file: %s, error: %v\n", outFile, err)
+	}
 }
 
 func outDir() string {

--- a/internal/pkg/debug/dump/dump.go
+++ b/internal/pkg/debug/dump/dump.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package dump contains functions for writing a function's SSA as SSA or DOT source to a file.
 package dump
 
 import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/google/go-flow-levee/internal/pkg/debug/render"
@@ -26,28 +28,22 @@ import (
 
 // SSA dumps a function's SSA to a file.
 func SSA(fileName string, f *ssa.Function) {
-	saveSSA(fileName, f.Name(), render.SSA(f))
-}
-
-func saveSSA(fileName, funcName, s string) {
-	save(fileName, funcName, s, "ssa")
+	save(fileName, f.Name(), render.SSA(f), "ssa")
 }
 
 // DOT dumps DOT source representing the function's SSA graph to a file.
 func DOT(fileName string, f *ssa.Function) {
-	saveDOT(fileName, f.Name(), render.DOT(f))
-}
-
-func saveDOT(fileName, funcName, s string) {
-	save(fileName, funcName, s, "dot")
+	save(fileName, f.Name(), render.DOT(f), "dot")
 }
 
 func save(fileName, funcName, s, ending string) {
-	outName := strings.TrimSuffix(fileName, ".go") + "_" + funcName + "." + ending
-	ioutil.WriteFile(filepath.Join(ensureExists("debug_output"), outName), []byte(s), 0666)
+	outFile := strings.TrimSuffix(fileName, ".go") + "_" + funcName + "." + ending
+	ioutil.WriteFile(filepath.Join(outDir(), outFile), []byte(s), 0666)
 }
 
-func ensureExists(dirName string) string {
-	os.MkdirAll(dirName, 0755)
-	return dirName
+func outDir() string {
+	_, currentFile, _, _ := runtime.Caller(0)
+	d := filepath.Join(filepath.Dir(currentFile), "../../../../output")
+	os.MkdirAll(d, 0755)
+	return d
 }

--- a/internal/pkg/debug/dump/dump.go
+++ b/internal/pkg/debug/dump/dump.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dump
 
 import (

--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -87,34 +87,36 @@ func (g *FuncGraph) visit(b *ssa.BasicBlock) {
 func (g *FuncGraph) visitOperands(n ssa.Node, s Stack) Stack {
 	var operands []*ssa.Value
 	operands = n.Operands(operands)
-	if operands != nil {
-		for _, o := range operands {
-			on, ok := (*o).(ssa.Node)
-			if !ok {
-				continue
-			}
-			g.addOperand(n, on)
-			if g.visited[on] {
-				continue
-			}
-			g.visited[on] = true
-			s.push(on)
+	if operands == nil {
+		return s
+	}
+	for _, o := range operands {
+		on, ok := (*o).(ssa.Node)
+		if !ok {
+			continue
 		}
+		g.addOperand(n, on)
+		if g.visited[on] {
+			continue
+		}
+		g.visited[on] = true
+		s.push(on)
 	}
 	return s
 }
 
 func (g *FuncGraph) visitReferrers(n ssa.Node, s Stack) Stack {
-	if n.Referrers() != nil {
-		for _, ref := range *n.Referrers() {
-			rn := ref.(ssa.Node)
-			g.addReferrer(n, rn)
-			if g.visited[rn] {
-				continue
-			}
-			g.visited[rn] = true
-			s.push(rn)
+	if n.Referrers() == nil {
+		return s
+	}
+	for _, ref := range *n.Referrers() {
+		rn := ref.(ssa.Node)
+		g.addReferrer(n, rn)
+		if g.visited[rn] {
+			continue
 		}
+		g.visited[rn] = true
+		s.push(rn)
 	}
 	return s
 }

--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -97,11 +97,7 @@ func (g *FuncGraph) visitOperands(n ssa.Node) {
 			continue
 		}
 		g.addOperand(n, on)
-		if g.visited[on] {
-			continue
-		}
-		g.visited[on] = true
-		g.push(on)
+		g.visitNode(on)
 	}
 }
 
@@ -112,12 +108,16 @@ func (g *FuncGraph) visitReferrers(n ssa.Node) {
 	for _, ref := range *n.Referrers() {
 		rn := ref.(ssa.Node)
 		g.addReferrer(n, rn)
-		if g.visited[rn] {
-			continue
-		}
-		g.visited[rn] = true
-		g.push(rn)
+		g.visitNode(rn)
 	}
+}
+
+func (g *FuncGraph) visitNode(n ssa.Node) {
+	if g.visited[n] {
+		return
+	}
+	g.visited[n] = true
+	g.push(n)
 }
 
 func (g *FuncGraph) addReferrer(current, referrer ssa.Node) {

--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -15,9 +15,6 @@
 package graph
 
 import (
-	"fmt"
-
-	"github.com/google/go-flow-levee/internal/pkg/debug/node"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -67,11 +64,6 @@ func (g *Graph) visit(b *ssa.BasicBlock) {
 	stack := []ssa.Node{n}
 	for len(stack) > 0 {
 		current := stack[len(stack)-1]
-
-		if node.CanonicalName(current) == "c" {
-			fmt.Println("referrers", len(*current.Referrers()))
-			fmt.Println("operands", len(current.Operands([]*ssa.Value{})))
-		}
 
 		stack = stack[:len(stack)-1]
 		var operands []*ssa.Value

--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -66,6 +66,10 @@ func (g *FuncGraph) visitBlocks() {
 }
 
 func (g *FuncGraph) visit(b *ssa.BasicBlock) {
+	if len(b.Instrs) == 0 {
+		return
+	}
+
 	n := b.Instrs[0].(ssa.Node)
 	g.visited[n] = true
 	s := Stack([]ssa.Node{n})

--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package graph
 
 import (

--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -1,0 +1,99 @@
+package graph
+
+import (
+	"fmt"
+
+	"github.com/google/go-flow-levee/internal/pkg/debug/node"
+	"golang.org/x/tools/go/ssa"
+)
+
+type NodeRelationship int
+
+const (
+	Referrer NodeRelationship = iota
+	Operand
+)
+
+type RelatedNode struct {
+	N ssa.Node
+	R NodeRelationship
+}
+
+type Graph struct {
+	// the function whose graph this is
+	F *ssa.Function
+	// a mapping from each node to its neighbors (referrers + operands)
+	Neighbors map[ssa.Node][]RelatedNode
+	// this is used while creating the graph to avoid needlessly revisiting nodes
+	visited map[ssa.Node]bool
+}
+
+// New returns a new Graph constructed from a given function.
+func New(f *ssa.Function) Graph {
+	g := Graph{
+		F:         f,
+		Neighbors: map[ssa.Node][]RelatedNode{},
+		visited:   map[ssa.Node]bool{},
+	}
+	g.visitBlocks()
+	return g
+}
+
+func (g *Graph) visitBlocks() {
+	for _, b := range g.F.Blocks {
+		g.visit(b)
+	}
+}
+
+func (g *Graph) visit(b *ssa.BasicBlock) {
+	n := b.Instrs[0].(ssa.Node)
+
+	g.visited[n] = true
+
+	stack := []ssa.Node{n}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+
+		if node.CanonicalName(current) == "c" {
+			fmt.Println("referrers", len(*current.Referrers()))
+			fmt.Println("operands", len(current.Operands([]*ssa.Value{})))
+		}
+
+		stack = stack[:len(stack)-1]
+		var operands []*ssa.Value
+		operands = current.Operands(operands)
+		if operands != nil {
+			for _, o := range operands {
+				on, ok := (*o).(ssa.Node)
+				if !ok {
+					continue
+				}
+				g.addOperand(current, on)
+				if g.visited[on] {
+					continue
+				}
+				g.visited[on] = true
+				stack = append(stack, on)
+			}
+		}
+		if current.Referrers() != nil {
+			for _, ref := range *current.Referrers() {
+				rn := ref.(ssa.Node)
+				g.addReferrer(current, rn)
+				if g.visited[rn] {
+					continue
+				}
+				g.visited[rn] = true
+				stack = append(stack, rn)
+			}
+		}
+	}
+}
+
+func (g *Graph) addReferrer(current, referrer ssa.Node) {
+	g.Neighbors[current] = append(g.Neighbors[current], RelatedNode{N: referrer, R: Referrer})
+}
+
+func (g *Graph) addOperand(current, operand ssa.Node) {
+	g.Neighbors[current] = append(g.Neighbors[current], RelatedNode{N: operand, R: Operand})
+}

--- a/internal/pkg/debug/node/node.go
+++ b/internal/pkg/debug/node/node.go
@@ -24,20 +24,22 @@ import (
 
 // CanonicalName produces a canonical string representation for an SSA node.
 func CanonicalName(n ssa.Node) string {
-	var target, op string
 	value, isValue := n.(ssa.Value)
 	instr, isInstr := n.(ssa.Instruction)
-	if isInstr {
-		op = instr.String()
-	}
-	if isValue {
-		if isInstr {
-			target = fmt.Sprintf("%s = ", value.Name())
-		} else {
-			target = value.Name()
+	switch {
+	case isValue && isInstr:
+		return fmt.Sprintf("%s = %s", value.Name(), instr.String())
+	case isValue:
+		return value.Name()
+	case isInstr:
+		return instr.String()
+	default:
+		member, isMember := n.(ssa.Member)
+		if !isMember {
+			return ""
 		}
+		return member.Name()
 	}
-	return target + op
 }
 
 // TrimmedType returns the type of a node without the "*.ssa" prefix.

--- a/internal/pkg/debug/node/node.go
+++ b/internal/pkg/debug/node/node.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package node contains utility functions for working with SSA nodes.
 package node
 
 import (

--- a/internal/pkg/debug/node/node.go
+++ b/internal/pkg/debug/node/node.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/internal/pkg/debug/node/node.go
+++ b/internal/pkg/debug/node/node.go
@@ -1,0 +1,32 @@
+package node
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// CanonicalName produces a canonical string representation for an SSA node.
+func CanonicalName(n ssa.Node) string {
+	var target, op string
+	value, isValue := n.(ssa.Value)
+	instr, isInstr := n.(ssa.Instruction)
+	if isInstr {
+		op = instr.String()
+	}
+	if isValue {
+		if isInstr {
+			target = fmt.Sprintf("%s = ", value.Name())
+		} else {
+			target = value.Name()
+		}
+	}
+	return target + op
+}
+
+// TrimmedType returns the type of a node without the "*.ssa" prefix.
+func TrimmedType(n ssa.Node) string {
+	t := fmt.Sprintf("%T", n)
+	return strings.TrimPrefix(t, "*ssa.")
+}

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -51,12 +51,12 @@ func (r *renderer) init() {
 
 func (r *renderer) writeSubgraphs() {
 	for bi, b := range r.F.Blocks {
-		_, _ = r.WriteString(fmt.Sprintf("\tsubgraph cluster_%d {\ncolor=black;\nlabel=%q;\n", bi, b.Comment))
+		_, _ = r.WriteString(fmt.Sprintf("\tsubgraph cluster_%d {\n\t\tcolor=black;\n\t\tlabel=%q;\n", bi, b.Comment))
 		for _, i := range b.Instrs {
 			n := i.(ssa.Node)
 			_, _ = r.WriteString(fmt.Sprintf("\t\t%q [shape=%s];\n", renderNode(n), nodeShape(n)))
 		}
-		_, _ = r.WriteString("}\n")
+		_, _ = r.WriteString("\t}\n")
 	}
 }
 

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -23,8 +23,6 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
-// TODO: render instruction/value nodes with different shapes (square, diamond, both)
-
 // DOT produces DOT source code representing the SSA graph for a function.
 func DOT(f *ssa.Function) string {
 	return renderDOT(graph.New(f))

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -46,17 +46,17 @@ func (r *renderer) Render() string {
 }
 
 func (r *renderer) init() {
-	r.WriteString("digraph {\n")
+	_, _ = r.WriteString("digraph {\n")
 }
 
 func (r *renderer) writeSubgraphs() {
 	for bi, b := range r.F.Blocks {
-		r.WriteString(fmt.Sprintf("subgraph cluster_%d {\ncolor=black;\nlabel=%q;\n", bi, b.Comment))
+		_, _ = r.WriteString(fmt.Sprintf("\tsubgraph cluster_%d {\ncolor=black;\nlabel=%q;\n", bi, b.Comment))
 		for _, i := range b.Instrs {
 			n := i.(ssa.Node)
-			r.WriteString(fmt.Sprintf("%q [shape=%s];\n", renderNode(n), nodeShape(n)))
+			_, _ = r.WriteString(fmt.Sprintf("\t\t%q [shape=%s];\n", renderNode(n), nodeShape(n)))
 		}
-		r.WriteString("}\n")
+		_, _ = r.WriteString("}\n")
 	}
 }
 
@@ -86,7 +86,7 @@ func (r *renderer) addOperand(n ssa.Node, op ssa.Node) {
 }
 
 func (r *renderer) addEdge(from ssa.Node, to ssa.Node, color string) {
-	r.WriteString(fmt.Sprintf("%q -> %q [color=%s];\n", renderNode(from), renderNode(to), color))
+	_, _ = r.WriteString(fmt.Sprintf("\t%q -> %q [color=%s];\n", renderNode(from), renderNode(to), color))
 }
 
 func renderNode(n ssa.Node) string {
@@ -94,13 +94,12 @@ func renderNode(n ssa.Node) string {
 }
 
 func (r *renderer) finish() {
-	r.WriteString("}\n")
+	_, _ = r.WriteString("}\n")
 }
 
 func nodeShape(n ssa.Node) string {
 	_, isValue := n.(ssa.Value)
 	_, isInstr := n.(ssa.Instruction)
-	// TODO: document this somewhere?
 	switch {
 	case isValue && isInstr:
 		return "diamond"

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -28,13 +28,13 @@ func DOT(f *ssa.Function) string {
 	return renderDOT(graph.New(f))
 }
 
-func renderDOT(g graph.Graph) string {
+func renderDOT(g *graph.FuncGraph) string {
 	return (&renderer{strings.Builder{}, g}).Render()
 }
 
 type renderer struct {
 	strings.Builder
-	graph.Graph
+	*graph.FuncGraph
 }
 
 func (r *renderer) Render() string {
@@ -61,8 +61,8 @@ func (r *renderer) writeSubgraphs() {
 }
 
 func (r *renderer) writeEdges() {
-	for from, neighbors := range r.Neighbors {
-		for _, to := range neighbors {
+	for from, children := range r.Children {
+		for _, to := range children {
 			switch to.R {
 			case graph.Referrer:
 				r.addReferrer(from, to.N)
@@ -106,8 +106,7 @@ func nodeShape(n ssa.Node) string {
 		return "diamond"
 	case isInstr:
 		return "square"
-	case isValue:
+	default:
 		return "ellipse"
 	}
-	panic(fmt.Sprintf("nodeShape: node %v is neither a Value nor an Instruction (impossible)", n))
 }

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -1,0 +1,100 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-flow-levee/internal/pkg/debug/graph"
+	"github.com/google/go-flow-levee/internal/pkg/debug/node"
+	"golang.org/x/tools/go/ssa"
+)
+
+// TODO: render instruction/value nodes with different shapes (square, diamond, both)
+
+// DOT produces DOT source code representing the SSA graph for a function.
+func DOT(f *ssa.Function) string {
+	return renderDOT(graph.New(f))
+}
+
+func renderDOT(g graph.Graph) string {
+	return (&renderer{strings.Builder{}, g}).Render()
+}
+
+type renderer struct {
+	strings.Builder
+	graph.Graph
+}
+
+func (r *renderer) Render() string {
+	r.init()
+	r.writeSubgraphs()
+	r.writeEdges()
+	r.finish()
+	return r.String()
+}
+
+func (r *renderer) init() {
+	r.WriteString("digraph {\n")
+}
+
+func (r *renderer) writeSubgraphs() {
+	for bi, b := range r.F.Blocks {
+		r.WriteString(fmt.Sprintf("subgraph cluster_%d {\ncolor=black;\nlabel=%q;\n", bi, b.Comment))
+		for _, i := range b.Instrs {
+			n := i.(ssa.Node)
+			r.WriteString(fmt.Sprintf("%q [shape=%s];\n", renderNode(n), nodeShape(n)))
+		}
+		r.WriteString("}\n")
+	}
+}
+
+func (r *renderer) writeEdges() {
+	for from, neighbors := range r.Neighbors {
+		for _, to := range neighbors {
+			switch to.R {
+			case graph.Referrer:
+				r.addReferrer(from, to.N)
+			case graph.Operand:
+				r.addOperand(from, to.N)
+			}
+		}
+	}
+}
+
+func (r *renderer) addReferrer(n ssa.Node, ref ssa.Node) {
+	// TODO: document this in the output?
+	// Red as in R-eferrer
+	r.addEdge(n, ref, "red")
+}
+
+func (r *renderer) addOperand(n ssa.Node, op ssa.Node) {
+	// TODO: document this in the output?
+	// Orange as in O-perand
+	r.addEdge(n, op, "orange")
+}
+
+func (r *renderer) addEdge(from ssa.Node, to ssa.Node, color string) {
+	r.WriteString(fmt.Sprintf("%q -> %q [color=%s];\n", renderNode(from), renderNode(to), color))
+}
+
+func renderNode(n ssa.Node) string {
+	return fmt.Sprintf("%s\n(%s)", node.CanonicalName(n), node.TrimmedType(n))
+}
+
+func (r *renderer) finish() {
+	r.WriteString("}\n")
+}
+
+func nodeShape(n ssa.Node) string {
+	_, isValue := n.(ssa.Value)
+	_, isInstr := n.(ssa.Instruction)
+	switch {
+	case isValue && isInstr:
+		return "diamond"
+	case isInstr:
+		return "square"
+	case isValue:
+		return "ellipse"
+	}
+	panic(fmt.Sprintf("nodeShape: node %v is neither a Value nor an Instruction (impossible)", n))
+}

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -74,13 +74,13 @@ func (r *renderer) writeEdges() {
 }
 
 func (r *renderer) addReferrer(n ssa.Node, ref ssa.Node) {
-	// TODO: document this in the output?
+	// TODO: document this somewhere?
 	// Red as in R-eferrer
 	r.addEdge(n, ref, "red")
 }
 
 func (r *renderer) addOperand(n ssa.Node, op ssa.Node) {
-	// TODO: document this in the output?
+	// TODO: document this somewhere?
 	// Orange as in O-perand
 	r.addEdge(n, op, "orange")
 }
@@ -100,6 +100,7 @@ func (r *renderer) finish() {
 func nodeShape(n ssa.Node) string {
 	_, isValue := n.(ssa.Value)
 	_, isInstr := n.(ssa.Instruction)
+	// TODO: document this somewhere?
 	switch {
 	case isValue && isInstr:
 		return "diamond"

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package render
 
 import (

--- a/internal/pkg/debug/render/ssa.go
+++ b/internal/pkg/debug/render/ssa.go
@@ -1,0 +1,27 @@
+package render
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-flow-levee/internal/pkg/debug/node"
+	"golang.org/x/tools/go/ssa"
+)
+
+// SSA produces a human-readable representation of the SSA code for a function.
+func SSA(f *ssa.Function) string {
+	var b strings.Builder
+	for i, blk := range f.Blocks {
+		b.WriteString(fmt.Sprintf("%d: %s\n", i, blk.Comment))
+		for j, instr := range blk.Instrs {
+			s := node.CanonicalName(instr.(ssa.Node))
+			b.WriteByte('\t')
+			b.WriteString(strconv.Itoa(j))
+			b.WriteString(fmt.Sprintf("(%-20T): ", instr))
+			b.WriteString(s)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}

--- a/internal/pkg/debug/render/ssa.go
+++ b/internal/pkg/debug/render/ssa.go
@@ -30,11 +30,11 @@ func SSA(f *ssa.Function) string {
 		b.WriteString(fmt.Sprintf("%d: %s\n", i, blk.Comment))
 		for j, instr := range blk.Instrs {
 			s := node.CanonicalName(instr.(ssa.Node))
-			b.WriteByte('\t')
-			b.WriteString(strconv.Itoa(j))
-			b.WriteString(fmt.Sprintf("(%-20T): ", instr))
-			b.WriteString(s)
-			b.WriteByte('\n')
+			_ = b.WriteByte('\t')
+			_, _ = b.WriteString(strconv.Itoa(j))
+			_, _ = b.WriteString(fmt.Sprintf("(%-20T): ", instr))
+			_, _ = b.WriteString(s)
+			_ = b.WriteByte('\n')
 		}
 	}
 	return b.String()

--- a/internal/pkg/debug/render/ssa.go
+++ b/internal/pkg/debug/render/ssa.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package render
 
 import (


### PR DESCRIPTION
Introduce code I've been using to produce SSA source + DOT source for quick perusal/visualization of test functions' SSA code.

This is a quick PR to see if you think that this approach is acceptable. I think it doesn't add too much clutter and will be very useful.

Caveats:
* Currently, the code is untested. This is because I have been iterating on it rapidly, and I believe tests would have merely slowed me down.

Misc. : 
* Should I mention this in the README?
* You may want to put a small script somewhere on your path to quickly generate PDF's or PNG's from DOT files 
e.g. `dotpdf.sh` : 
```sh
for f in "$@"; do
	dot -Tpdf "$f" -o "$(basename "$f" .dot).pdf"
done
```
E.g. : `dotpdf sinks_TestSinks.dot`

- [x] Tests pass
- [x] Appropriate changes to README are included in PR