### PR TITLE
Use fieldtags analyzer in fieldpropagator analyzer

### DIFF
--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -50,7 +50,7 @@ A field propagator is a function that returns a source field.`,
 	FactTypes:  []analysis.Fact{new(isFieldPropagator)},
 }
 
-type Analysis struct {
+type analysisState struct {
 	pass     *analysis.Pass
 	conf     *config.Config
 	ssaInput *buildssa.SSA
@@ -66,7 +66,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, err
 	}
 
-	a := &Analysis{
+	a := &analysisState{
 		pass:     pass,
 		conf:     conf,
 		ssaInput: ssaInput,
@@ -81,7 +81,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return FieldPropagators(isFieldPropagator), nil
 }
 
-func (a *Analysis) run() {
+func (a *analysisState) run() {
 	ssaProg := a.ssaInput.Pkg.Prog
 	for _, mem := range a.ssaInput.Pkg.Members {
 		ssaType, ok := mem.(*ssa.Type)
@@ -96,7 +96,7 @@ func (a *Analysis) run() {
 	}
 }
 
-func (a *Analysis) analyzeBlocks(meth *ssa.Function) {
+func (a *analysisState) analyzeBlocks(meth *ssa.Function) {
 	// Function does not return anything
 	if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
 		return
@@ -114,7 +114,7 @@ func (a *Analysis) analyzeBlocks(meth *ssa.Function) {
 	}
 }
 
-func (a *Analysis) analyzeResults(meth *ssa.Function, results []ssa.Value) {
+func (a *analysisState) analyzeResults(meth *ssa.Function, results []ssa.Value) {
 	for _, r := range results {
 		fa, ok := fieldAddr(r)
 		if !ok {

--- a/internal/pkg/fieldpropagator/testdata/src/source/test.go
+++ b/internal/pkg/fieldpropagator/testdata/src/source/test.go
@@ -15,6 +15,7 @@
 package source
 
 type Source struct {
+	secret  string `levee:"source"`
 	data    string
 	dataPtr *string
 	id      int
@@ -22,6 +23,10 @@ type Source struct {
 
 func (s Source) ID() int {
 	return s.id
+}
+
+func (s Source) Secret() string { // want Secret:"field propagator identified"
+	return s.secret
 }
 
 func (s Source) Data() string { // want Data:"field propagator identified"

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -42,10 +42,10 @@ var patterns sourcePatterns = []keyValue{
 	{"levee", "source"},
 }
 
-// TaggedFields is named type representing a slice of Tagged Fields.
+// TaggedFields is named type representing a slice of TaggedFields.
 type TaggedFields []TaggedField
 
-// ResultType is a slice of Tagged Fields.
+// ResultType is a slice of TaggedFields.
 type ResultType = TaggedFields
 
 // A TaggedField contains the necessary information to identify a tagged struct field.
@@ -149,7 +149,7 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 
 // IsSource determines whether a FieldAddr is a source, that is whether it refers to a field previously identified as a source.
 func (t TaggedFields) IsSource(f *ssa.FieldAddr) bool {
-	n, ok := named(f)
+	n, ok := namedType(f)
 	if !ok {
 		return false
 	}
@@ -162,7 +162,7 @@ func (t TaggedFields) IsSource(f *ssa.FieldAddr) bool {
 	return false
 }
 
-func named(f *ssa.FieldAddr) (*types.Named, bool) {
+func namedType(f *ssa.FieldAddr) (*types.Named, bool) {
 	structType := f.X.Type()
 	deref := utils.Dereference(structType)
 	named, ok := deref.(*types.Named)

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,9 +15,9 @@
 package fieldtags
 
 type Person struct {
-	password           string      `levee:"source"`               // want "tagged field"
-	secret             string      `json:"secret" levee:"source"` // want "tagged field"
-	another            interface{} "levee:\"source\""             // want "tagged field"
+	password           string      `levee:"source"`               // want "tagged field: fieldtags.Person.password"
+	secret             string      `json:"secret" levee:"source"` // want "tagged field: fieldtags.Person.secret"
+	another            interface{} "levee:\"source\""             // want "tagged field: fieldtags.Person.another"
 	name               string      `some_key:"non_secret"`
 	someNotTaggedField int
 }


### PR DESCRIPTION
## This PR

This PR enhances the `fieldpropagator` analyzer's ability to detect field propagators by allowing it to use the results of the `fieldtags` analyzer. (The `fieldtags` analyzer was unused up to now.)

## Future PRs (in order)
1. Make this configurable, with the current setting of `levee:"source"` as a default.
2. Use the `fieldtags` analyzer in the `source` analyzer.

## Outstanding
* Should we mark a tagged field as a Source even if it is not on a Source type?
  - I would say no.
  - Currently, we do. This would be easy to change, however.
* Should we produce a warning when we detect a field tagged as a Source that is not on a Source type?
  - I would say yes, e.g. "warning: field tagged as source on non-source type; this field will not be used as a source"

- [x] Tests pass
- [x] Appropriate changes to README are included in PR