### PR TITLE
Use more appropriate shapes in .dot debug output

### DIFF
--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -102,7 +102,7 @@ func nodeShape(n ssa.Node) string {
 	_, isInstr := n.(ssa.Instruction)
 	switch {
 	case isValue && isInstr:
-		return "square"
+		return "rectangle"
 	case isInstr:
 		return "diamond"
 	default:

--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -102,9 +102,9 @@ func nodeShape(n ssa.Node) string {
 	_, isInstr := n.(ssa.Instruction)
 	switch {
 	case isValue && isInstr:
-		return "diamond"
-	case isInstr:
 		return "square"
+	case isInstr:
+		return "diamond"
 	default:
 		return "ellipse"
 	}


### PR DESCRIPTION
(This is just a small QOL change).

## Changes
* Use rectangles instead of diamonds for `ssa.Node`s that are *both* instructions and values.
* Use diamonds instead of squares for `ssa.Node`s that are merely instructions.

## Justification
As it turns out, most `ssa.Node`s are both instructions and values. Some of them have rather lengthy string representations. The "diamond" shape does not accommodate this nicely, producing unsightly nodes such as this :
![image](https://user-images.githubusercontent.com/28677454/90534397-af685780-e147-11ea-8e05-1af219543185.png)
Nodes that are merely `Instructions` usually have short string representations, so using "diamond" for them is not a problem.

What a rectangle looks like : 
![image](https://user-images.githubusercontent.com/28677454/90534919-5220d600-e148-11ea-974b-c1399b4b1cf0.png)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR