### PR TITLE
Remove reference to propagators in source test

### DIFF
--- a/internal/pkg/source/source_test.go
+++ b/internal/pkg/source/source_test.go
@@ -28,11 +28,10 @@ import (
 )
 
 type testConfig struct {
-	sourcePattern      string
-	propagatorsPattern string
-	fieldsPattern      string
-	sanitizerPattern   string
-	sinkPattern        string
+	sourcePattern    string
+	fieldsPattern    string
+	sanitizerPattern string
+	sinkPattern      string
 }
 
 func (c *testConfig) IsSource(t types.Type) bool {
@@ -71,11 +70,10 @@ var testAnalyzer = &analysis.Analyzer{
 func runTest(pass *analysis.Pass) (interface{}, error) {
 	in := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
 	config := &testConfig{
-		sourcePattern:      `\.foo`,
-		propagatorsPattern: "propagator",
-		sanitizerPattern:   "sanitizer",
-		fieldsPattern:      "name",
-		sinkPattern:        "sink",
+		sourcePattern:    `\.foo`,
+		sanitizerPattern: "sanitizer",
+		fieldsPattern:    "name",
+		sinkPattern:      "sink",
 	}
 
 	sm := identify(config, in)


### PR DESCRIPTION
Since we no longer have an explicit source code representation of the concept of a "propagator", this test should not refer to it anymore.

This should probably have been in #51.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR