### PR TITLE
Introduce function abstraction for cross-function analysis

### DIFF
--- a/internal/pkg/cfa/function.go
+++ b/internal/pkg/cfa/function.go
@@ -86,12 +86,23 @@ func newGenericFunc(f *ssa.Function) GenericFunc {
 	}
 }
 
-func (g GenericFunc) Sinks(arg int) bool {
-	return g.sinks[arg]
+// Sinks returns whether the GenericFunc's nth argument reaches a sink.
+// This function will panic if `n` is out of range,
+// i.e. n <= 0 || n >= len(g.sinks)
+// Such a panic can only occur due to a programming error, which should
+// be caught during development.
+func (g GenericFunc) Sinks(n int) bool {
+	return g.sinks[n]
 }
 
-func (g GenericFunc) Taints(arg int) []int {
-	return g.taints[arg]
+// Taints returns the positions of the return values reached by GenericFunc's
+// nth argument.
+// This function will panic if `n` is out of range,
+// i.e. n <= 0 || n >= len(g.sinks)
+// Such a panic can only occur due to a programming error, which should
+// be caught during development.
+func (g GenericFunc) Taints(n int) []int {
+	return g.taints[n]
 }
 
 func (g GenericFunc) String() string {
@@ -123,7 +134,7 @@ func (g GenericFunc) String() string {
 	return b.String()
 }
 
-// Results returns the number of return values that this function has.
+// Results returns the number of results (return values) that this function has.
 func (g GenericFunc) Results() int {
 	return g.results
 }

--- a/internal/pkg/cfa/function.go
+++ b/internal/pkg/cfa/function.go
@@ -67,29 +67,34 @@ func (s sanitizer) String() string {
 	return "sanitizer"
 }
 
-type genericFunc struct {
+// A GenericFunc is a generic Go function, i.e. neither a sink nor a sanitizer.
+// As such, each of its arguments may or may not reach a sink. Also, each of
+// its arguments may taint 0 or more of its return values.
+// Because it may taint its return values, GenericFunc provides a way for
+// users to know how many results (return values) it has.
+type GenericFunc struct {
 	sinks   []bool
 	taints  [][]int
 	results int
 }
 
-func newGenericFunc(f *ssa.Function) genericFunc {
+func newGenericFunc(f *ssa.Function) GenericFunc {
 	params := f.Signature.Params().Len()
-	return genericFunc{
+	return GenericFunc{
 		sinks:  make([]bool, params),
 		taints: make([][]int, params),
 	}
 }
 
-func (g genericFunc) Sinks(arg int) bool {
+func (g GenericFunc) Sinks(arg int) bool {
 	return g.sinks[arg]
 }
 
-func (g genericFunc) Taints(arg int) []int {
+func (g GenericFunc) Taints(arg int) []int {
 	return g.taints[arg]
 }
 
-func (g genericFunc) String() string {
+func (g GenericFunc) String() string {
 	var b strings.Builder
 	b.WriteString("genericFunc{ ")
 
@@ -119,6 +124,6 @@ func (g genericFunc) String() string {
 }
 
 // Results returns the number of return values that this function has.
-func (g genericFunc) Results() int {
+func (g GenericFunc) Results() int {
 	return g.results
 }

--- a/internal/pkg/cfa/function.go
+++ b/internal/pkg/cfa/function.go
@@ -67,17 +67,17 @@ func (s sanitizer) String() string {
 	return "sanitizer"
 }
 
-// A GenericFunc is a generic Go function, i.e. neither a sink nor a sanitizer.
+// A genericFunc is a generic Go function, i.e. neither a sink nor a sanitizer.
 // As such, each of its arguments may or may not reach a sink. Also, each of
 // its arguments may taint 0 or more of its return values.
-type GenericFunc struct {
+type genericFunc struct {
 	sinks  []bool
 	taints [][]int
 }
 
-func newGenericFunc(f *ssa.Function) GenericFunc {
+func newGenericFunc(f *ssa.Function) genericFunc {
 	params := f.Signature.Params().Len()
-	return GenericFunc{
+	return genericFunc{
 		sinks:  make([]bool, params),
 		taints: make([][]int, params),
 	}
@@ -88,7 +88,7 @@ func newGenericFunc(f *ssa.Function) GenericFunc {
 // i.e. n <= 0 || n >= len(g.sinks)
 // Such a panic can only occur due to a programming error, which should
 // be caught during development.
-func (g GenericFunc) Sinks(n int) bool {
+func (g genericFunc) Sinks(n int) bool {
 	return g.sinks[n]
 }
 
@@ -98,11 +98,11 @@ func (g GenericFunc) Sinks(n int) bool {
 // i.e. n <= 0 || n >= len(g.sinks)
 // Such a panic can only occur due to a programming error, which should
 // be caught during development.
-func (g GenericFunc) Taints(n int) []int {
+func (g genericFunc) Taints(n int) []int {
 	return g.taints[n]
 }
 
-func (g GenericFunc) String() string {
+func (g genericFunc) String() string {
 	var b strings.Builder
 	b.WriteString("genericFunc{ ")
 

--- a/internal/pkg/cfa/function.go
+++ b/internal/pkg/cfa/function.go
@@ -70,12 +70,9 @@ func (s sanitizer) String() string {
 // A GenericFunc is a generic Go function, i.e. neither a sink nor a sanitizer.
 // As such, each of its arguments may or may not reach a sink. Also, each of
 // its arguments may taint 0 or more of its return values.
-// Because it may taint its return values, GenericFunc provides a way for
-// users to know how many results (return values) it has.
 type GenericFunc struct {
-	sinks   []bool
-	taints  [][]int
-	results int
+	sinks  []bool
+	taints [][]int
 }
 
 func newGenericFunc(f *ssa.Function) GenericFunc {
@@ -132,9 +129,4 @@ func (g GenericFunc) String() string {
 	b.WriteString(strings.Join(taints, " "))
 	b.WriteString("> }")
 	return b.String()
-}
-
-// Results returns the number of results (return values) that this function has.
-func (g GenericFunc) Results() int {
-	return g.results
 }

--- a/internal/pkg/cfa/function.go
+++ b/internal/pkg/cfa/function.go
@@ -1,0 +1,124 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cfa implements cross-function analysis. The analyzer
+// defined in this package looks at every function in the transitive
+// dependencies of the program being analyzed and creates an abstraction
+// for each one that can be used to determine what the function does with
+// each of its arguments.
+
+package cfa
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// A Function is an abstraction for a Go function.
+// It can be queried about what it does with its arguments.
+type Function interface {
+	// Does this function's nth argument reach a sink?
+	Sinks(arg int) bool
+
+	// If this argument is tainted, which return values are tainted?
+	Taints(arg int) []int
+}
+
+type sink struct{}
+
+func (s sink) Sinks(_ int) bool {
+	return true
+}
+
+func (s sink) Taints(_ int) []int {
+	return nil
+}
+
+func (s sink) String() string {
+	return "sink"
+}
+
+type sanitizer struct{}
+
+func (s sanitizer) Sinks(_ int) bool {
+	return false
+}
+
+func (s sanitizer) Taints(_ int) []int {
+	return nil
+}
+
+func (s sanitizer) String() string {
+	return "sanitizer"
+}
+
+type genericFunc struct {
+	sinks   []bool
+	taints  [][]int
+	results int
+}
+
+func newGenericFunc(f *ssa.Function) genericFunc {
+	params := f.Signature.Params().Len()
+	return genericFunc{
+		sinks:  make([]bool, params),
+		taints: make([][]int, params),
+	}
+}
+
+func (g genericFunc) Sinks(arg int) bool {
+	return g.sinks[arg]
+}
+
+func (g genericFunc) Taints(arg int) []int {
+	return g.taints[arg]
+}
+
+func (g genericFunc) String() string {
+	var b strings.Builder
+	b.WriteString("genericFunc{ ")
+
+	b.WriteString("sinks: <")
+	var reached []string
+	for i, reachesSink := range g.sinks {
+		if reachesSink {
+			reached = append(reached, strconv.Itoa(i))
+		}
+	}
+	b.WriteString(strings.Join(reached, " "))
+	b.WriteByte('>')
+
+	b.WriteString(", taints: <")
+	var taints []string
+	for _, ts := range g.taints {
+		sort.Ints(ts)
+		var tainted []string
+		for _, t := range ts {
+			tainted = append(tainted, strconv.Itoa(t))
+		}
+		taints = append(taints, fmt.Sprintf("<%v>", strings.Join(tainted, " ")))
+	}
+	b.WriteString(strings.Join(taints, " "))
+	b.WriteString("> }")
+	return b.String()
+}
+
+// Results returns the number of return values that this function has.
+func (g genericFunc) Results() int {
+	return g.results
+}


### PR DESCRIPTION
(This PR is intended as a precursor to #57 to reduce the diff.)

This PR introduces a `Function` abstraction that can be used to query a function about what it does with its arguments. Among other things, having such an abstraction will allow us to handle the following cases:

```
func SinksFive(s core.Source) {
	five := ReturnsFive(s)
	core.Sink(five)
}

func ReturnsFive(a interface{}) int {
	return 5
}
```
Currently, when a function is called with a tainted value, we traverse through its return value no matter what the function's behavior is. Here, `ReturnsFive` returns a value that is not tainted, as can be seen easily by analyzing its body. Our current analysis does not know about that though, and it assumes the return value is tainted, so it incorrectly produces a diagnostic for `core.Sink(five)`. Using the abstraction introduced in this PR would allow us to handle this case in the following way:
1. Analyze the body of the `ReturnsFive` function. Discover that it does not sink its argument, nor does its argument taint any of its return values.
2. While analyzing the body of `SinksFive`, we find a call to `ReturnsFive` that takes a `Source` as argument. We ask the `ReturnsFive` function if it sinks that argument, and it says no. We then ask it if its return value is tainted by this argument. It once again says no, so we know we do not need to traverse through the return value, preventing us from reaching the sink, avoiding a false positive diagnostic.

```
func TestStringify(s core.Source) {
	s := Stringify(e)
	core.Sink(s)
}

func Stringify(e interface{}) string {
	return fmt.Sprintf("%v", e)
}
```
In this case, the value returned by `Stringify` *is* tainted if its `e interface{}` argument is tainted. Analyzing the body of `Stringify` would tell us that, and then while analyzing `TestStringify` we would traverse through the tainted return value to find the call to `core.Sink`.

The following are not handled by the proposed abstraction:
- Methods
- Tainting of colocated arguments, e.g. `fmt.Fprintf(w, Source{})`

(I think for a first stab at cross-function analysis, handling those is out of scope.)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR