### PR TITLE
WIP: Add tests for propagation through colocated arguments

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -37,3 +37,8 @@ func TestSinkArgumentWriterTaintedBySource(w io.Writer, s core.Source) {
 	_, _ = fmt.Fprintf(w, "%v", s)
 	core.Sink(w) // want "a source has reached a sink"
 }
+
+func TestSinkArgumentWriterTaintedBySourceAfterSinkCall(w io.Writer, s core.Source) {
+	core.Sink(w)
+	_, _ = fmt.Fprintf(w, "%v", s)
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -24,7 +24,7 @@ import (
 type writer struct{}
 
 func (w *writer) Write(bytes []byte) (n int, err error) {
-	return len(bytes), nil
+	return 0, nil
 }
 
 func TestSinkAllocatedWriterTaintedBySource(s core.Source) {

--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -16,6 +16,7 @@ package colocation
 
 import (
 	"fmt"
+	"io"
 
 	"example.com/core"
 )
@@ -26,8 +27,13 @@ func (w *writer) Write(bytes []byte) (n int, err error) {
 	return len(bytes), nil
 }
 
-func TestSinkWriterTaintedBySource(s core.Source) {
+func TestSinkAllocatedWriterTaintedBySource(s core.Source) {
 	w := writer{}
 	_, _ = fmt.Fprintf(&w, "%v", s)
 	core.Sink(w) // TODO want "a source has reached a sink"
+}
+
+func TestSinkArgumentWriterTaintedBySource(w io.Writer, s core.Source) {
+	_, _ = fmt.Fprintf(w, "%v", s)
+	core.Sink(w) // want "a source has reached a sink"
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colocation
+
+import (
+	"fmt"
+
+	"example.com/core"
+)
+
+type writer struct{}
+
+func (w *writer) Write(bytes []byte) (n int, err error) {
+	return len(bytes), nil
+}
+
+func TestSinkWriterTaintedBySource(s core.Source) {
+	w := writer{}
+	_, _ = fmt.Fprintf(&w, "%v", s)
+	core.Sink(w) // TODO want "a source has reached a sink"
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -39,6 +39,7 @@ func TestSinkArgumentWriterTaintedBySource(w io.Writer, s core.Source) {
 }
 
 func TestSinkArgumentWriterTaintedBySourceAfterSinkCall(w io.Writer, s core.Source) {
+	// TODO: this should not produce a diagnostic
 	core.Sink(w)
 	_, _ = fmt.Fprintf(w, "%v", s)
 }


### PR DESCRIPTION
This PR adds a (currently failing) test for propagation through colocated arguments, e.g. : 

`fmt.Fprintf(w, format, source) // w is now tainted`

The full test is this : 
```
func TestSinkAllocatedWriterTaintedBySource(s core.Source) {
	w := writer{}
	_, _ = fmt.Fprintf(&w, "%v", s)
	core.Sink(w) // TODO want "a source has reached a sink"
}
```

Originally, I expected the test to pass because currently the analysis generally traverses through every Referrer/Operand reachable from a source, so I was expecting it to traverse through the `&w` argument in the call to `fmt.Fprintf` and subsequently find its way to the call to `core.Sink`. The following image shows why this does not happen:

![image](https://user-images.githubusercontent.com/28677454/91067454-ee435500-e600-11ea-826d-abcca0caf8ff.png)

In order to get to the call to `core.Sink`, the traversal has to go through an `ssa.Alloc` instruction. Currently, we do not traverse through `ssa.Alloc`s that allocate anything other than a `types.Array` (in the source code, this could be an array, a slice or a varargs):
`source.go:119`
```
		if al, isAlloc := (*o).(*ssa.Alloc); isAlloc {
			if _, isArray := utils.Dereference(al.Type()).(*types.Array); !isArray {
				return
			}
		}
```

Note that there is no problem if the `io.Writer` is received as an argument:
```
func TestSinkArgumentWriterTaintedBySource(w io.Writer, s core.Source) {
	_, _ = fmt.Fprintf(w, "%v", s)
	core.Sink(w) // want "a source has reached a sink"
}
```
(this is because there is no alloc for the writer).

However, the following test case fails with an unexpected diagnostic:
```
func TestSinkArgumentWriterTaintedBySourceAfterSinkCall(w io.Writer, s core.Source) {
	core.Sink(w) // unexpected diagnostic produced here
	_, _ = fmt.Fprintf(w, "%v", s)
}
```
At first glance, this seems to be due to the fact that the SSA graph does not know about the order of the the instructions, so if we simply traverse the graph we have no way to know that the call to `core.Sink` occurs before the call to `fmt.Fprintf`. I am currently investigating how to fix this rather sorry state of affairs.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR