### PR TITLE
Fix bug in config.IsSinkFunction

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -59,9 +59,8 @@ func (c Config) IsSinkFunction(f *ssa.Function) bool {
 		return false
 	}
 
-	recv := f.Signature.Recv()
 	var recvName string
-	if recv != nil {
+	if recv := f.Signature.Recv(); recv != nil {
 		recvName = recv.Type().String()
 	}
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -59,12 +59,20 @@ func (c Config) IsSinkFunction(f *ssa.Function) bool {
 		return false
 	}
 
+	recv := f.Signature.Recv()
+	var recvName string
+	if recv != nil {
+		recvName = recv.Type().String()
+	}
+
 	for _, p := range c.Sinks {
-		if p.PackageRE.MatchString(f.Pkg.Pkg.Name()) && p.MethodRE.MatchString(f.Name()) {
+		if !p.PackageRE.MatchString(f.Pkg.Pkg.Name()) || !p.MethodRE.MatchString(f.Name()) {
+			continue
+		}
+		if p.ReceiverRE.MatchString(recvName) {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -53,8 +53,14 @@ func (c Config) IsSink(call *ssa.Call) bool {
 }
 
 func (c Config) IsSinkFunction(f *ssa.Function) bool {
+	// according to the documentation for ssa.Function, this can happen if
+	// f is a "shared func", e.g. "wrappers and error.Error"
+	if f.Pkg == nil {
+		return false
+	}
+
 	for _, p := range c.Sinks {
-		if p.MethodRE.MatchString(f.Name()) {
+		if p.PackageRE.MatchString(f.Pkg.Pkg.Name()) && p.MethodRE.MatchString(f.Name()) {
 			return true
 		}
 	}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+var testAnalyzer = &analysis.Analyzer{
+	Name:     "config",
+	Run:      runTest,
+	Doc:      "test harness for the logic related to config",
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+func runTest(pass *analysis.Pass) (interface{}, error) {
+	in := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+
+	conf, err := ReadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range in.SrcFuncs {
+		if conf.IsSinkFunction(f) {
+			pass.Reportf(f.Pos(), "sink")
+		}
+	}
+
+	return nil, nil
+}
+
+func TestConfig(t *testing.T) {
+	testdata := analysistest.TestData()
+	if err := FlagSet.Set("config", filepath.Join(testdata, "test-config.json")); err != nil {
+		t.Fatal(err)
+	}
+	analysistest.Run(t, testdata, testAnalyzer, "core", "notcore")
+}

--- a/internal/pkg/config/testdata/src/core/core.go
+++ b/internal/pkg/config/testdata/src/core/core.go
@@ -1,5 +1,25 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core
 
 func Sink() {} // want "sink"
 
 func NotSink() {}
+
+type Sinker struct{}
+
+func (s Sinker) Do() {} // want "sink"
+
+func (s Sinker) DoNot() {}

--- a/internal/pkg/config/testdata/src/core/core.go
+++ b/internal/pkg/config/testdata/src/core/core.go
@@ -1,0 +1,5 @@
+package core
+
+func Sink() {} // want "sink"
+
+func NotSink() {}

--- a/internal/pkg/config/testdata/src/notcore/notcore.go
+++ b/internal/pkg/config/testdata/src/notcore/notcore.go
@@ -1,5 +1,25 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notcore
 
 func Sink() {}
 
 func NotSink() {}
+
+type Sinker struct{}
+
+func (s Sinker) Do() {}
+
+func (s Sinker) DoNot() {}

--- a/internal/pkg/config/testdata/src/notcore/notcore.go
+++ b/internal/pkg/config/testdata/src/notcore/notcore.go
@@ -1,0 +1,5 @@
+package notcore
+
+func Sink() {}
+
+func NotSink() {}

--- a/internal/pkg/config/testdata/test-config.json
+++ b/internal/pkg/config/testdata/test-config.json
@@ -1,0 +1,8 @@
+{
+  "Sinks": [
+    {
+      "PackageRE": "^core$",
+      "MethodRE": "^Sink"
+    }
+  ]
+}

--- a/internal/pkg/config/testdata/test-config.json
+++ b/internal/pkg/config/testdata/test-config.json
@@ -3,6 +3,11 @@
     {
       "PackageRE": "^core$",
       "MethodRE": "^Sink$"
+    },
+    {
+      "PackageRE": "^core$",
+      "MethodRE": "^Do$",
+      "TypeRE": "^Sinker$"
     }
   ]
 }

--- a/internal/pkg/config/testdata/test-config.json
+++ b/internal/pkg/config/testdata/test-config.json
@@ -2,7 +2,7 @@
   "Sinks": [
     {
       "PackageRE": "^core$",
-      "MethodRE": "^Sink"
+      "MethodRE": "^Sink$"
     }
   ]
 }


### PR DESCRIPTION
## The bug
`config.IsSinkFunction` completely disregards the function's package when determining whether an `ssa.Function` is a sink. It only looks at the function's name.

## The fix
The immediate fix is simply to verify that the function's package matches the config. However, I've also added a test for it, because I've actually run into this bug a few times now while writing tests for other packages (e.g., `levee` and `source`), and I want some confidence that it won't happen again.

## Future PR's
Since the `config` package is not tested directly right now, I intend to add more tests in future PR's in order to avoid these kinds of bugs. Having direct test coverage will also increase our ability to refactor the code safely.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR