### PR TITLE
Take instruction order into account when visiting calls

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/tests.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callorder
+
+import (
+	"fmt"
+	"io"
+
+	"example.com/core"
+)
+
+func TestTaintBeforeSinking(s core.Source, w io.Writer) {
+	_, _ = fmt.Fprintf(w, "%v", s)
+	core.Sink(w) // want "a source has reached a sink"
+}
+
+func TestSinkBeforeTainting(s core.Source, w io.Writer) {
+	core.Sink(w)
+	_, _ = fmt.Fprintf(w, "%v", s)
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/tests.go
@@ -30,3 +30,9 @@ func TestSinkBeforeTainting(s core.Source, w io.Writer) {
 	core.Sink(w)
 	_, _ = fmt.Fprintf(w, "%v", s)
 }
+
+func TestSinkBeforeAndAfterTainting(s core.Source, w io.Writer) {
+	core.Sink(w)
+	_, _ = fmt.Fprintf(w, "%v", s)
+	core.Sink(w) // want "a source has reached a sink"
+}

--- a/internal/pkg/sanitizer/sanitizer.go
+++ b/internal/pkg/sanitizer/sanitizer.go
@@ -57,11 +57,5 @@ func (s Sanitizer) Dominates(target ssa.Instruction) bool {
 		return sanitizationIdx < targetIdx
 	}
 
-	for _, d := range s.Call.Block().Dominees() {
-		if target.Block() == d {
-			return true
-		}
-	}
-
 	return false
 }


### PR DESCRIPTION
## The bug
Currently, the analyzer does not differentiate between the following two (abstract) scenarios:
1. Bad
```
taint(value)
sink(value)
```
2. Ok
```
sink(value)
taint(value)
```
Specifically, in this second case, a diagnostic is produced at the `sink` call, even though the `value` has not yet been `taint`ed. This is because we rely mostly on the SSA value graph to determine if a source reaches a sink, and that graph has no concept of the "order" of instructions: it only contains `Referrers`/`Operands` relationships.

## The fix
While traversing from a `Source`, for each `ssa.BasicBlock`, we keep track of the max index of an instruction visited within it. 
When we visit an instruction, we find its index in its block and update the max seen so far if necessary. When we encounter a `Call` instruction, we check that it is higher than the current max for its block, i.e. that it occurs after the value that led us to the call was tainted.

## Future PR's
The solution proposed here only works for single-block functions. If a function has multiple blocks, in most cases this approach will not work as is, so I will need to extend it in a future PR.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR