### PR TITLE
Remove unnecessary loop over dominees

### DIFF
--- a/internal/pkg/sanitizer/sanitizer.go
+++ b/internal/pkg/sanitizer/sanitizer.go
@@ -57,11 +57,5 @@ func (s Sanitizer) Dominates(target ssa.Instruction) bool {
 		return sanitizationIdx < targetIdx
 	}
 
-	for _, d := range s.Call.Block().Dominees() {
-		if target.Block() == d {
-			return true
-		}
-	}
-
 	return false
 }


### PR DESCRIPTION
In `sanitizer.go` : 
```go
func (s Sanitizer) Dominates(target ssa.Instruction) bool {

	...

	if !s.Call.Block().Dominates(target.Block()) {
		return false
	}

	...

	for _, d := range s.Call.Block().Dominees() {
		if target.Block() == d {
			return true
		}
	}

	return false
}
```

If the sanitizer's block does not dominate the target's block, then the target block won't be found in the sanitizer's block's dominees. Hence, the loop is unnecessary. Removing it fails no tests.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR