### PR TITLE
Add tests for propagation through channels

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/chans.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/chans.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections
+
+import (
+	"example.com/core"
+)
+
+func TestSourceReceivedFromChannelIsTainted(sources <-chan core.Source) {
+	s := <-sources
+	core.Sink(s) // want "a source has reached a sink"
+}
+
+func TestChannelIsTaintedWhenSourceIsPlacedOnIt(sources chan<- core.Source) {
+	sources <- core.Source{}
+	core.Sink(sources) // want "a source has reached a sink"
+}
+
+func TestValueObtainedFromTaintedChannelIsTainted(c chan interface{}) {
+	c <- core.Source{}
+	s := <-c
+	core.Sink(s) // want "a source has reached a sink"
+}
+
+func TestChannelIsNoLongerTaintedWhenNilledOut(sources chan core.Source) {
+	sources <- core.Source{}
+	sources = nil
+	core.Sink(sources)
+}


### PR DESCRIPTION
See the test cases for details.

## Discussion
One place where channels differ from other collections is that logging a channel typically does not reveal its contents. Because of that, it may not make much sense to produce a report when a channel is sinked. (It would be possible for a user to write a custom logger that empties a channel and writes its content to some form of log, but that would be rather odd).

In fact, in general a user is unlikely to log a channel. They might log a structure that contains a channel, though.

For our analysis, it is useful to consider that a channel can be tainted, because that makes it easy to recognize that a value obtained from such a channel is also tainted.

I think the way it works right now is acceptable. We could add some code to avoid producing a report when the tainted value being sinked is a channel, but I don't think it's worth it. (Plus if our users do write weird custom loggers they will expect reports if they are used incorrectly).

- [x] Tests pass
- [x] Appropriate changes to README are included in PR