### PR TITLE
Use facts in fieldtags analyzer

### DIFF
--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,9 +15,9 @@
 package fieldtags
 
 type Person struct {
-	password           string      `levee:"source"`               // want "tagged field: fieldtags.Person.password"
-	secret             string      `json:"secret" levee:"source"` // want "tagged field: fieldtags.Person.secret"
-	another            interface{} "levee:\"source\""             // want "tagged field: fieldtags.Person.another"
+	password           string      `levee:"source"`               // want password:"tagged field"
+	secret             string      `json:"secret" levee:"source"` // want secret:"tagged field"
+	another            interface{} "levee:\"source\""             // want another:"tagged field"
 	name               string      `some_key:"non_secret"`
 	someNotTaggedField int
 }


### PR DESCRIPTION
This PR is a precursor to #68.

While integrating the `fieldtags` analyzer with the `source` analyzer, I ran into some issues that made me want to rework the `fieldtags` analyzer.

For one thing, currently the `fieldtags` analyzer uses strings to represent fields, which is not very robust. It is much simpler and more reliable to use `types.Object`s. We can get the `types.Object` for an `ast.Ident` node by using `pass.TypesInfo.ObjectOf`.

The rest of the code mirrors the pattern used in the `fieldpropagators` analyzer, namely:
1. while analyzing, export facts for tagged fields
2. when the main analysis is done, collect the exported facts and wrap them up into a result other analyzers can use.

**More fundamentally,** we need to have some way to carry information about tagged fields over the course of the analysis. Consider:
```go
package core

type Source struct {
  field string `levee:"source"`
}
```

```go
package usescore

import "core"

func main() {
  f := core.Source{}.field
}
```
Under the current implementation, while the `source` analyzer is running on the `usescore` package, it does not receive any tagged fields from the `fieldtags` analyzer, because the tagged fields are in `core`, not `usescore`.

Typically, analyzer `Result`s are the results for the analysis performed on a specific package. However, in this case we need to carry the knowledge of which tagged fields are sources to the importing packages. Otherwise, when a tagged field is accessed in an importing package, we have no way to tell.

It seems to me the most straightforward way to do this is to use `Fact`s. For additional context, see the `fieldpropagators` analyzer, in which we are already using this pattern.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR