### PR TITLE
Integrate fieldtags analyzer with source analyzer

### DIFF
--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,9 +15,9 @@
 package fieldtags
 
 type Person struct {
-	password           string      `levee:"source"`               // want "tagged field: fieldtags.Person.password"
-	secret             string      `json:"secret" levee:"source"` // want "tagged field: fieldtags.Person.secret"
-	another            interface{} "levee:\"source\""             // want "tagged field: fieldtags.Person.another"
+	password           string      `levee:"source"`               // want password:"tagged field"
+	secret             string      `json:"secret" levee:"source"` // want secret:"tagged field"
+	another            interface{} "levee:\"source\""             // want another:"tagged field"
 	name               string      `some_key:"non_secret"`
 	someNotTaggedField int
 }

--- a/internal/pkg/levee/testdata/src/example.com/core/source.go
+++ b/internal/pkg/levee/testdata/src/example.com/core/source.go
@@ -15,9 +15,11 @@
 package core
 
 // Source will be configured to be detected as a source struct, with Source.Data as the source field.
+// Source.Tagged is also a source field, as indicated by the field tag.
 type Source struct {
-	Data string
-	ID   int
+	Data   string
+	Tagged string `levee:"source"`
+	ID     int
 }
 
 func (s Source) GetID() int {
@@ -26,6 +28,10 @@ func (s Source) GetID() int {
 
 func (s Source) GetData() string {
 	return s.Data
+}
+
+func (s Source) GetTagged() string {
+	return s.Tagged
 }
 
 // Innocuous will _not_ be configured to be a source, even though underlying types are equal.

--- a/internal/pkg/levee/testdata/src/example.com/tests/fields/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/fields/tests.go
@@ -20,15 +20,18 @@ import (
 )
 
 func TestFieldAccessors(s core.Source, ptr *core.Source) {
-	core.Sinkf("Data: %v", s.GetData()) // want "a source has reached a sink"
+	core.Sinkf("Data: %v", s.GetData())     // want "a source has reached a sink"
+	core.Sinkf("Tagged: %v", s.GetTagged()) // want "a source has reached a sink"
 	core.Sinkf("ID: %v", s.GetID())
 
-	core.Sinkf("Data: %v", ptr.GetData()) // want "a source has reached a sink"
+	core.Sinkf("Data: %v", ptr.GetData())     // want "a source has reached a sink"
+	core.Sinkf("Tagged: %v", ptr.GetTagged()) // want "a source has reached a sink"
 	core.Sinkf("ID: %v", ptr.GetID())
 }
 
 func TestDirectFieldAccess(c *core.Source) {
-	core.Sinkf("Data: %v", c.Data) // want "a source has reached a sink"
+	core.Sinkf("Data: %v", c.Data)     // want "a source has reached a sink"
+	core.Sinkf("Tagged: %v", c.Tagged) // want "a source has reached a sink"
 	core.Sinkf("ID: %v", c.ID)
 }
 
@@ -37,11 +40,13 @@ func TestProtoStyleFieldAccessorSanitizedPII(c *core.Source) {
 }
 
 func TestProtoStyleFieldAccessorPIISecondLevel(wrapper struct{ *core.Source }) {
-	core.Sinkf("Source data: %v", wrapper.Source.GetData()) // want "a source has reached a sink"
+	core.Sinkf("Source data: %v", wrapper.Source.GetData())     // want "a source has reached a sink"
+	core.Sinkf("Source tagged: %v", wrapper.Source.GetTagged()) // want "a source has reached a sink"
 	core.Sinkf("Source id: %v", wrapper.Source.GetID())
 }
 
-func tesDirectFieldAccessorPIISecondLevel(wrapper struct{ *core.Source }) {
-	core.Sinkf("Source data: %v", wrapper.Source.Data) // want "a source has reached a sink"
+func TestDirectFieldAccessorPIISecondLevel(wrapper struct{ *core.Source }) {
+	core.Sinkf("Source data: %v", wrapper.Source.Data)     // want "a source has reached a sink"
+	core.Sinkf("Source tagged: %v", wrapper.Source.Tagged) // want "a source has reached a sink"
 	core.Sinkf("Source id: %v", wrapper.Source.ID)
 }

--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/google/go-flow-levee/internal/pkg/config"
+	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"
@@ -30,7 +31,7 @@ var Analyzer = &analysis.Analyzer{
 	Doc:        "This analyzer identifies ssa.Values as dataflow sources.",
 	Flags:      config.FlagSet,
 	Run:        run,
-	Requires:   []*analysis.Analyzer{buildssa.Analyzer},
+	Requires:   []*analysis.Analyzer{buildssa.Analyzer, fieldtags.Analyzer},
 	ResultType: reflect.TypeOf(new(ResultType)).Elem(),
 }
 
@@ -39,13 +40,14 @@ var Analyzer = &analysis.Analyzer{
 var reporting bool
 
 func run(pass *analysis.Pass) (interface{}, error) {
+	taggedFields := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
 	ssaInput := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
 	conf, err := config.ReadConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	sourceMap := identify(conf, ssaInput)
+	sourceMap := identify(conf, ssaInput, taggedFields)
 
 	if reporting {
 		for _, srcs := range sourceMap {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -20,6 +20,7 @@ import (
 	"go/types"
 	"strings"
 
+	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"github.com/google/go-flow-levee/internal/pkg/sanitizer"
 	"github.com/google/go-flow-levee/internal/pkg/utils"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
@@ -38,11 +39,12 @@ type classifier interface {
 // its referrers.
 // Source.sanitized notes sanitizer calls that sanitize this Source
 type Source struct {
-	node       ssa.Node
-	marked     map[ssa.Node]bool
-	preOrder   []ssa.Node
-	sanitizers []*sanitizer.Sanitizer
-	config     classifier
+	node         ssa.Node
+	marked       map[ssa.Node]bool
+	preOrder     []ssa.Node
+	sanitizers   []*sanitizer.Sanitizer
+	config       classifier
+	taggedFields fieldtags.TaggedFields
 }
 
 // Node returns the underlying ssa.Node of the Source.
@@ -51,11 +53,12 @@ func (a *Source) Node() ssa.Node {
 }
 
 // New constructs a Source
-func New(in ssa.Node, config classifier) *Source {
+func New(in ssa.Node, config classifier, taggedFields fieldtags.TaggedFields) *Source {
 	a := &Source{
-		node:   in,
-		marked: make(map[ssa.Node]bool),
-		config: config,
+		node:         in,
+		marked:       make(map[ssa.Node]bool),
+		config:       config,
+		taggedFields: taggedFields,
 	}
 	a.dfs(in)
 	return a
@@ -95,7 +98,7 @@ func (a *Source) visitReferrers(referrers *[]ssa.Instruction) {
 				a.sanitizers = append(a.sanitizers, &sanitizer.Sanitizer{Call: v})
 			}
 		case *ssa.FieldAddr:
-			if !a.config.IsSourceFieldAddr(v) {
+			if !a.config.IsSourceFieldAddr(v) && !a.taggedFields.IsSource(v) {
 				continue
 			}
 		}
@@ -171,7 +174,7 @@ func (a *Source) String() string {
 	return b.String()
 }
 
-func identify(conf classifier, ssaInput *buildssa.SSA) map[*ssa.Function][]*Source {
+func identify(conf classifier, ssaInput *buildssa.SSA, taggedFields fieldtags.TaggedFields) map[*ssa.Function][]*Source {
 	sourceMap := make(map[*ssa.Function][]*Source)
 
 	for _, fn := range ssaInput.SrcFuncs {
@@ -181,9 +184,9 @@ func identify(conf classifier, ssaInput *buildssa.SSA) map[*ssa.Function][]*Sour
 		}
 
 		var sources []*Source
-		sources = append(sources, sourcesFromParams(fn, conf)...)
-		sources = append(sources, sourcesFromClosure(fn, conf)...)
-		sources = append(sources, sourcesFromBlocks(fn, conf)...)
+		sources = append(sources, sourcesFromParams(fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromClosure(fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromBlocks(fn, conf, taggedFields)...)
 
 		if len(sources) > 0 {
 			sourceMap[fn] = sources
@@ -192,13 +195,13 @@ func identify(conf classifier, ssaInput *buildssa.SSA) map[*ssa.Function][]*Sour
 	return sourceMap
 }
 
-func sourcesFromParams(fn *ssa.Function, conf classifier) []*Source {
+func sourcesFromParams(fn *ssa.Function, conf classifier, taggedFields fieldtags.TaggedFields) []*Source {
 	var sources []*Source
 	for _, p := range fn.Params {
 		switch t := p.Type().(type) {
 		case *types.Pointer:
 			if n, ok := t.Elem().(*types.Named); ok && conf.IsSource(n) {
-				sources = append(sources, New(p, conf))
+				sources = append(sources, New(p, conf, taggedFields))
 			}
 			// TODO Handle the case where sources arepassed by value: func(c sourceType)
 			// TODO Handle cases where PII is wrapped in struct/slice/map
@@ -207,7 +210,7 @@ func sourcesFromParams(fn *ssa.Function, conf classifier) []*Source {
 	return sources
 }
 
-func sourcesFromClosure(fn *ssa.Function, conf classifier) []*Source {
+func sourcesFromClosure(fn *ssa.Function, conf classifier, taggedFields fieldtags.TaggedFields) []*Source {
 	var sources []*Source
 	for _, p := range fn.FreeVars {
 		switch t := p.Type().(type) {
@@ -215,14 +218,14 @@ func sourcesFromClosure(fn *ssa.Function, conf classifier) []*Source {
 			// FreeVars (variables from a closure) appear as double-pointers
 			// Hence, the need to dereference them recursively.
 			if s, ok := utils.Dereference(t).(*types.Named); ok && conf.IsSource(s) {
-				sources = append(sources, New(p, conf))
+				sources = append(sources, New(p, conf, taggedFields))
 			}
 		}
 	}
 	return sources
 }
 
-func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
+func sourcesFromBlocks(fn *ssa.Function, conf classifier, taggedFields fieldtags.TaggedFields) []*Source {
 	var sources []*Source
 	for _, b := range fn.Blocks {
 		if b == fn.Recover {
@@ -235,14 +238,14 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 			// Looking for sources of PII allocated within the body of a function.
 			case *ssa.Alloc:
 				if conf.IsSource(utils.Dereference(v.Type())) && !isProducedBySanitizer(v, conf) {
-					sources = append(sources, New(v, conf))
+					sources = append(sources, New(v, conf, taggedFields))
 				}
 
 				// Handling the case where PII may be in a receiver
 				// (ex. func(b *something) { log.Info(something.PII) }
 			case *ssa.FieldAddr:
-				if conf.IsSource(utils.Dereference(v.Type())) {
-					sources = append(sources, New(v, conf))
+				if conf.IsSource(utils.Dereference(v.Type())) || taggedFields.IsSource(v) {
+					sources = append(sources, New(v, conf, taggedFields))
 				}
 			}
 		}

--- a/internal/pkg/source/source_test.go
+++ b/internal/pkg/source/source_test.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"github.com/google/go-flow-levee/internal/pkg/utils"
 
 	"golang.org/x/tools/go/analysis"
@@ -64,11 +65,13 @@ var testAnalyzer = &analysis.Analyzer{
 	Name:     "source",
 	Run:      runTest,
 	Doc:      "test harness for the logic related to sources",
-	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+	Requires: []*analysis.Analyzer{buildssa.Analyzer, fieldtags.Analyzer},
 }
 
 func runTest(pass *analysis.Pass) (interface{}, error) {
 	in := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+	taggedFields := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
+
 	config := &testConfig{
 		sourcePattern:    `\.foo`,
 		sanitizerPattern: "sanitizer",
@@ -76,7 +79,7 @@ func runTest(pass *analysis.Pass) (interface{}, error) {
 		sinkPattern:      "sink",
 	}
 
-	sm := identify(config, in)
+	sm := identify(config, in, taggedFields)
 	for _, f := range sm {
 		for _, s := range f {
 			if s.String() != "" {


### PR DESCRIPTION
This PR is built on #67.

This PR integrates the `fieldtags` analyzer into the `source` analyzer, allowing identification of tagged fields as sources.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR