### PR TITLE
Prepare fieldtags analyzer for integration with sourcetype analyzer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/google/go-flow-levee
 
 go 1.14
 
-require golang.org/x/tools v0.0.0-20200416214402-fc959738d646
+require (
+	github.com/google/go-cmp v0.5.2
+	golang.org/x/tools v0.0.0-20200416214402-fc959738d646
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -79,7 +79,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return FieldPropagators(isFieldPropagator), nil
 }
 
-func analyzeBlocks(pass *analysis.Pass, conf *config.Config, tf fieldtags.TaggedFields, meth *ssa.Function) {
+func analyzeBlocks(pass *analysis.Pass, conf *config.Config, tf fieldtags.ResultType, meth *ssa.Function) {
 	// Function does not return anything
 	if res := meth.Signature.Results(); res == nil || (*res).Len() == 0 {
 		return
@@ -97,7 +97,7 @@ func analyzeBlocks(pass *analysis.Pass, conf *config.Config, tf fieldtags.Tagged
 	}
 }
 
-func analyzeResults(pass *analysis.Pass, conf *config.Config, tf fieldtags.TaggedFields, meth *ssa.Function, results []ssa.Value) {
+func analyzeResults(pass *analysis.Pass, conf *config.Config, tf fieldtags.ResultType, meth *ssa.Function, results []ssa.Value) {
 	for _, r := range results {
 		fa, ok := fieldAddr(r)
 		if !ok {

--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -103,7 +103,7 @@ func analyzeResults(pass *analysis.Pass, conf *config.Config, tf fieldtags.Tagge
 		if !ok {
 			continue
 		}
-		if conf.IsSourceFieldAddr(fa) || tf.IsSource(fa) {
+		if conf.IsSourceFieldAddr(fa) || tf.IsSourceFieldAddr(fa) {
 			pass.ExportObjectFact(meth.Object(), &isFieldPropagator{})
 		}
 	}

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -39,12 +39,9 @@ var patterns sourcePatterns = []keyValue{
 	{"levee", "source"},
 }
 
-// TaggedFields is a map from types.Object to bool.
+// ResultType is a map from types.Object to bool.
 // It can be used to determine whether a field is a tagged Source field.
-type TaggedFields map[types.Object]bool
-
-// ResultType is a slice of TaggedFields.
-type ResultType = TaggedFields
+type ResultType map[types.Object]bool
 
 var Analyzer = &analysis.Analyzer{
 	Name: "fieldtags",

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -143,7 +143,7 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 
 // IsSourceFieldAddr determines whether a ssa.FieldAddr is a source, that is whether it refers to a field previously identified as a source.
 func (t TaggedFields) IsSourceFieldAddr(fa *ssa.FieldAddr) bool {
-	// incantation plundered from the documentation for ssa.FieldAddr
+	// incantation plundered from the docstring for ssa.FieldAddr.Field
 	field := fa.X.Type().Underlying().(*types.Pointer).Elem().Underlying().(*types.Struct).Field(fa.Field)
 	return t.IsSource(field)
 }

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -139,13 +139,13 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 }
 
 // IsSourceFieldAddr determines whether a ssa.FieldAddr is a source, that is whether it refers to a field previously identified as a source.
-func (t TaggedFields) IsSourceFieldAddr(fa *ssa.FieldAddr) bool {
+func (r ResultType) IsSourceFieldAddr(fa *ssa.FieldAddr) bool {
 	// incantation plundered from the docstring for ssa.FieldAddr.Field
 	field := fa.X.Type().Underlying().(*types.Pointer).Elem().Underlying().(*types.Struct).Field(fa.Field)
-	return t.IsSource(field)
+	return r.IsSource(field)
 }
 
 // IsSource determines whether a types.Var is a source, that is whether it refers to a field previously identified as a source.
-func (t TaggedFields) IsSource(field *types.Var) bool {
-	return t[(types.Object)(field)]
+func (r ResultType) IsSource(field *types.Var) bool {
+	return r[(types.Object)(field)]
 }

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -72,10 +72,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 		for _, f := range (*s).Fields.List {
 			if patterns.isSource(f) && len(f.Names) > 0 {
-				fName := f.Names[0]
-				obj := pass.TypesInfo.ObjectOf(fName)
-				taggedFields[obj] = true
-				pass.Reportf(f.Pos(), "tagged field: %s", fName)
+				fNames := make([]string, len(f.Names))
+				for i, ident := range f.Names {
+					fNames[i] = ident.Name
+					taggedFields[pass.TypesInfo.ObjectOf(ident)] = true
+				}
+				pass.Reportf(f.Pos(), "tagged field: %s", strings.Join(fNames, ", "))
 			}
 		}
 	})

--- a/internal/pkg/fieldtags/analyzer_test.go
+++ b/internal/pkg/fieldtags/analyzer_test.go
@@ -17,11 +17,33 @@ package fieldtags
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func TestFieldTagsAnalysis(t *testing.T) {
 	testdata := analysistest.TestData()
 
-	analysistest.Run(t, testdata, Analyzer, "tests")
+	results := analysistest.Run(t, testdata, Analyzer, "tests")
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	want := []string{
+		"password",
+		"creds",
+		"secret",
+		"another",
+	}
+
+	var got []string
+	for o := range results[0].Result.(ResultType) {
+		got = append(got, o.Name())
+	}
+
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+		t.Errorf("Tagged Fields diff (-want +got):\n%s", diff)
+	}
 }

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,9 +15,9 @@
 package fieldtags
 
 type Person struct {
-	password           string      `levee:"source"`               // want "tagged field: fieldtags.Person.password"
-	secret             string      `json:"secret" levee:"source"` // want "tagged field: fieldtags.Person.secret"
-	another            interface{} "levee:\"source\""             // want "tagged field: fieldtags.Person.another"
+	password           string      `levee:"source"`               // want "tagged field: password"
+	secret             string      `json:"secret" levee:"source"` // want "tagged field: secret"
+	another            interface{} "levee:\"source\""             // want "tagged field: another"
 	name               string      `some_key:"non_secret"`
 	someNotTaggedField int
 }

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,7 +15,7 @@
 package fieldtags
 
 type Person struct {
-	password             string      `levee:"source"`               // want "tagged field: password"
+	password, creds      string      `levee:"source"`               // want "tagged field: password, creds"
 	secret               string      `json:"secret" levee:"source"` // want "tagged field: secret"
 	another              interface{} "levee:\"source\""             // want "tagged field: another"
 	name                 string      `some_key:"non_secret"`


### PR DESCRIPTION
This PR is a precursor to #71.

This PR prepares integration with the `sourcetype` analyzer by modifying the `fieldtags` analyzer to work with `types.Object`s. This is useful because the `sourcetype` analyzer works with `types.Var`s, which are `types.Object`s.

Working with `types.Object`s also makes the `fieldtags` analyzer more robust. Currently, it is working with strings, and in fact it contains a bug: it uses `Pkg.Name()` instead of `Pkg.Path()` when recording the string that represents a field's package. Using `types.Object`s makes the code simpler and more likely to be correct.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR