### PR TITLE
Fix JSON typo in example config

### DIFF
--- a/configuration/example-config.json
+++ b/configuration/example-config.json
@@ -28,5 +28,5 @@
       "MethodRE": "Info|Warning|Error|Fatal|Exit"
     }
   ],
-  "Sanitizers": [],
+  "Sanitizers": []
 }


### PR DESCRIPTION
Ran into an issue with the config while trying to run the analyzer on kubernetes: there is an extraneous comma in the JSON.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR