### PR TITLE
Fix possible out of bounds string access

### DIFF
--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -109,6 +109,7 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 		for j < len(tag) && tag[j] != ':' {
 			j++
 		}
+
 		key := tag[i:j]
 		if key == "" {
 			return false

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -115,6 +115,9 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 		}
 
 		i = j + 1 // skip colon
+		if i > len(tag) {
+			return false
+		}
 		if tag[i] == '\\' {
 			i++
 		}

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -115,7 +115,7 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 		}
 
 		i = j + 1 // skip colon
-		if i > len(tag) {
+		if i >= len(tag) {
 			return false
 		}
 		if tag[i] == '\\' {

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -109,7 +109,6 @@ func (sp *sourcePatterns) isSource(field *ast.Field) bool {
 		for j < len(tag) && tag[j] != ':' {
 			j++
 		}
-
 		key := tag[i:j]
 		if key == "" {
 			return false

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,9 +15,10 @@
 package fieldtags
 
 type Person struct {
-	password           string      `levee:"source"`               // want "tagged field: fieldtags.Person.password"
-	secret             string      `json:"secret" levee:"source"` // want "tagged field: fieldtags.Person.secret"
-	another            interface{} "levee:\"source\""             // want "tagged field: fieldtags.Person.another"
-	name               string      `some_key:"non_secret"`
-	someNotTaggedField int
+	password             string      `levee:"source"`               // want "tagged field: fieldtags.Person.password"
+	secret               string      `json:"secret" levee:"source"` // want "tagged field: fieldtags.Person.secret"
+	another              interface{} "levee:\"source\""             // want "tagged field: fieldtags.Person.another"
+	name                 string      `some_key:"non_secret"`
+	spaceAfterFinalQuote string      `key:"value" `
+	someNotTaggedField   int
 }


### PR DESCRIPTION
While running the analyzer on kubernetes, I ran into an out of bounds string access. This PR fixes the code that caused it.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR