### PR TITLE
Use unqualified receiver name when checking receiver type in config.IsSink(Function)

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"go/types"
 	"io/ioutil"
+	"strings"
 	"sync"
 
 	"github.com/google/go-flow-levee/internal/pkg/config/regexp"
@@ -61,7 +62,7 @@ func (c Config) IsSinkFunction(f *ssa.Function) bool {
 
 	var recvName string
 	if recv := f.Signature.Recv(); recv != nil {
-		recvName = recv.Type().String()
+		recvName = unqualifiedName(recv)
 	}
 
 	for _, p := range c.Sinks {
@@ -176,10 +177,19 @@ func (r callMatcher) Match(c *ssa.Call) bool {
 	recv := c.Call.Signature().Recv()
 	var recvName string
 	if recv != nil {
-		recvName = recv.Type().String()
+		recvName = unqualifiedName(recv)
 	}
 
 	return r.ReceiverRE.MatchString(recvName)
+}
+
+func unqualifiedName(v *types.Var) string {
+	packageQualifiedName := v.Type().String()
+	dotPos := strings.LastIndexByte(packageQualifiedName, '.')
+	if dotPos == -1 {
+		return packageQualifiedName
+	}
+	return packageQualifiedName[dotPos+1:]
 }
 
 var readFileOnce sync.Once

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -52,5 +52,7 @@ func TestConfig(t *testing.T) {
 	if err := FlagSet.Set("config", filepath.Join(testdata, "test-config.json")); err != nil {
 		t.Fatal(err)
 	}
-	analysistest.Run(t, testdata, testAnalyzer, "core", "notcore")
+	for _, p := range []string{"core", "notcore", "crosspkg"} {
+		analysistest.Run(t, testdata, testAnalyzer, filepath.Join(testdata, "src/example.com", p))
+	}
 }

--- a/internal/pkg/config/testdata/src/example.com/core/core.go
+++ b/internal/pkg/config/testdata/src/example.com/core/core.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+func Sink() {} // want "sink"
+
+func NotSink() {}
+
+type Sinker struct{}
+
+func (s Sinker) Do() {} // want "sink"
+
+func (s Sinker) DoNot() {}
+
+func Calls() {
+	Sink() // want "sink call"
+	NotSink()
+	s := Sinker{}
+	s.Do() // want "sink call"
+	s.DoNot()
+}

--- a/internal/pkg/config/testdata/src/example.com/core/core.go
+++ b/internal/pkg/config/testdata/src/example.com/core/core.go
@@ -24,10 +24,16 @@ func (s Sinker) Do() {} // want "sink"
 
 func (s Sinker) DoNot() {}
 
+type NotSinker struct{}
+
+func (ns NotSinker) Do() {}
+
 func Calls() {
 	Sink() // want "sink call"
 	NotSink()
 	s := Sinker{}
 	s.Do() // want "sink call"
 	s.DoNot()
+	ns := NotSinker{}
+	ns.Do()
 }

--- a/internal/pkg/config/testdata/src/example.com/crosspkg/crosspkg.go
+++ b/internal/pkg/config/testdata/src/example.com/crosspkg/crosspkg.go
@@ -12,14 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package crosspkg
 
-func Sink() {} // want "sink"
+import (
+	"example.com/core"
+	"example.com/notcore"
+)
 
-func NotSink() {}
+func CoreCalls() {
+	core.Sink() // want "sink call"
+	core.NotSink()
+	s := core.Sinker{}
+	s.Do() // want "sink call"
+	s.DoNot()
+}
 
-type Sinker struct{}
-
-func (s Sinker) Do() {} // want "sink"
-
-func (s Sinker) DoNot() {}
+func NotCoreCalls() {
+	notcore.Sink()
+	notcore.NotSink()
+	s := notcore.Sinker{}
+	s.Do()
+	s.DoNot()
+}

--- a/internal/pkg/config/testdata/src/example.com/crosspkg/crosspkg.go
+++ b/internal/pkg/config/testdata/src/example.com/crosspkg/crosspkg.go
@@ -38,8 +38,6 @@ func NotCoreCalls() {
 
 func NotExampleComCalls() {
 	necore.Sink()
-	necore.NotSink()
 	s := necore.Sinker{}
 	s.Do()
-	s.DoNot()
 }

--- a/internal/pkg/config/testdata/src/example.com/notcore/notcore.go
+++ b/internal/pkg/config/testdata/src/example.com/notcore/notcore.go
@@ -23,3 +23,11 @@ type Sinker struct{}
 func (s Sinker) Do() {}
 
 func (s Sinker) DoNot() {}
+
+func Calls() {
+	Sink()
+	NotSink()
+	s := Sinker{}
+	s.Do()
+	s.DoNot()
+}

--- a/internal/pkg/config/testdata/src/notexample.com/core/core.go
+++ b/internal/pkg/config/testdata/src/notexample.com/core/core.go
@@ -16,10 +16,6 @@ package core
 
 func Sink() {}
 
-func NotSink() {}
-
 type Sinker struct{}
 
 func (s Sinker) Do() {}
-
-func (s Sinker) DoNot() {}

--- a/internal/pkg/config/testdata/test-config.json
+++ b/internal/pkg/config/testdata/test-config.json
@@ -7,7 +7,7 @@
     {
       "PackageRE": "^example.com/core$",
       "MethodRE": "^Do$",
-      "TypeRE": "^Sinker$"
+      "ReceiverRE": "^Sinker$"
     }
   ]
 }

--- a/internal/pkg/config/testdata/test-config.json
+++ b/internal/pkg/config/testdata/test-config.json
@@ -1,11 +1,11 @@
 {
   "Sinks": [
     {
-      "PackageRE": "^core$",
+      "PackageRE": "^example.com/core$",
       "MethodRE": "^Sink$"
     },
     {
-      "PackageRE": "^core$",
+      "PackageRE": "^example.com/core$",
       "MethodRE": "^Do$",
       "TypeRE": "^Sinker$"
     }


### PR DESCRIPTION
## Context

While running tests on kubernetes, I discovered that sources reaching sink method calls were not being reported.

## The bug(s)

There are at least 2 bugs, the first of which is addressed by the current PR. The second will be addressed in a future PR.
1. We use `recv.Type().String()` as the name of a receiver. That string actually includes the whole package path as well. So if the config says the receiver name is `^Source$`, we won't get a match because we'll compare the regex to e.g. `example.com/core.Source`.
2. We do not reach method calls while we are traversing from a source. This is due to the following snippet in `source.go:visitReferrers()`:
```
if v.Call.Signature().Recv() != nil {
    continue
}
```

## This PR

This PR fixes the 1st bug by checking the unqualified names of receivers (e.g. `Source`) instead of their fully qualified names (e.g. `example.com/core.Source`). 

## Why did we not catch this before?

Simply because these cases do not occur in our tests.

The 1st bug was not covered due to an unfortunate mistake on my part. In a past PR #69 that added cross-package tests for `config.IsSinkFunction`, I used `TypeRE` instead of `ReceiverRE` as a field in the object describing the `Sinker.Do` sink. Because of that, the regexp for that `callMatcher`'s `ReceiverRE` had a `nil` regexp, so it was matching everything. We were also missing a negative case, which could have allowed us to catch this.

In relation to that, I think it would be useful for us, and for our users, to do some JSON validation. We should at least check that the user isn't providing a bogus field.

The 2nd bug was not covered because we don't have any method sinks in the tests for levee. This will be resolved in the PR that fixes the bug.

## Future PR's

In addition to the PR fixing the 2nd bug, I intend to write an additional PR that will refactor the code involving `Function`s and `Call`s. This code contains a lot of duplication right now. I also intend to write tests for other parts of the config that are currently untested, or tested indirectly via levee and other analyzers.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR