### PR TITLE
Fix false positives due to propagation through extracts

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -22,7 +22,7 @@ func CreateSource() (core.Source, error) {
 	return core.Source{}, nil
 }
 
-func CreateSourceRetvalsFlipped() (error, core.Source) {
+func CreateSourceFlipped() (error, core.Source) {
 	return nil, core.Source{}
 }
 
@@ -42,19 +42,19 @@ func TestOnlySourceExtractIsTaintedInstructionOrder() {
 	core.Sink(s) // want "a source has reached a sink"
 }
 
+func TestOnlySourceExtractIsTaintedFlipped() {
+	err, s := CreateSourceFlipped()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
 func TestOnlySourceExtractIsTaintedInstructionOrderFlipped() {
-	err, s := CreateSourceRetvalsFlipped()
-	core.Sink(s) // want "a source has reached a sink"
-	core.Sink(err)
-}
-
-func TestExtractsFlipped() {
-	err, s := CreateSourceRetvalsFlipped()
+	err, s := CreateSourceFlipped()
 	core.Sink(err)
 	core.Sink(s) // want "a source has reached a sink"
 }
 
-func TestExtractsFromCallWithSourceArg(s core.Source) {
+func TestExtractsFromCallWithSourceArgAreTainted(s core.Source) {
 	str, i, e := TakeSource(s)
 	core.Sink(str) // want "a source has reached a sink"
 	core.Sink(i)   // want "a source has reached a sink"

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extracts
+
+import (
+	"example.com/core"
+)
+
+func CreateSource() (core.Source, error) {
+	return core.Source{}, nil
+}
+
+func CreateSourceRetvalsFlipped() (error, core.Source) {
+	return nil, core.Source{}
+}
+
+func TakeSource(s core.Source) (string, int, interface{}) {
+	return "", 0, nil
+}
+
+func TestOnlySourceExtractIsTainted() {
+	s, err := CreateSource()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
+func TestOnlySourceExtractIsTaintedInstructionOrder() {
+	s, err := CreateSource()
+	core.Sink(err)
+	core.Sink(s) // want "a source has reached a sink"
+}
+
+func TestOnlySourceExtractIsTaintedInstructionOrderFlipped() {
+	err, s := CreateSourceRetvalsFlipped()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
+func TestExtractsFlipped() {
+	err, s := CreateSourceRetvalsFlipped()
+	core.Sink(err)
+	core.Sink(s) // want "a source has reached a sink"
+}
+
+func TestExtractsFromCallWithSourceArg(s core.Source) {
+	str, i, e := TakeSource(s)
+	core.Sink(str) // want "a source has reached a sink"
+	core.Sink(i)   // want "a source has reached a sink"
+	core.Sink(e)   // want "a source has reached a sink"
+}


### PR DESCRIPTION
## The bug
While running the analyzer on kubernetes, I got a false positive report for an error value that was returned from a function that returns two values: a `Source` value and an `error`. Here is an abstract example:
```go
func CreateSource() (core.Source, error) {
	return core.Source{}, nil
}

func TestExtracts() {
	s, err := CreateSource()
	core.Sink(err) // unexpected diagnostic here
	_ = s
}
```
Just because the `error` value is returned next to a `Source`, that doesn't mean it should be tainted.

## The problem

The core of the problem is that we are traversing to nodes that we shouldn't be traversing to. Consider the following piece of an SSA graph:
![image](https://user-images.githubusercontent.com/28677454/92034025-a62bdd00-ed3a-11ea-8f8f-ef817b884199.png)

While scanning the instructions, the code in `source.go:sourcesFromBlocks` will find the `Alloc` and create a `Source` from it, which will start a DFS. The DFS reaches the `Extract`, which is used to extract the `Source` from the tuple created that is returned by the `CreateSource` function. The problem is that with the current call, the traversal continues through the `Call`, and into the other `Extract` (not shown in the image), which leads to the call to `core.Sink`, and therefore an unexpected diagnostic.

## The fix

The fix is simply to avoid traversing to a `Call` from an `Extract`. The tainted `Extract` will have the `Source`-producing call as an `Operand`, which just need to avoid it.

## Additional details

The tests cover a variety of failure cases that I ran into while developing this fix.

The last test case documents a logical extension of current behavior, namely that if a function takes a `Source` as argument, we consider its return value(s) to be tainted.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR