### PR TITLE
Fix: identify sources in extracts

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/core/source.go
+++ b/internal/pkg/levee/testdata/src/example.com/core/source.go
@@ -28,6 +28,14 @@ func (s Source) GetData() string {
 	return s.Data
 }
 
+func (s Source) Copy() (Source, error) {
+	return s, nil
+}
+
+func (s Source) CopyPointer() (*Source, error) {
+	return &s, nil
+}
+
 // Innocuous will _not_ be configured to be a source, even though underlying types are equal.
 type Innocuous struct {
 	Data string

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -22,7 +22,7 @@ func CreateSource() (core.Source, error) {
 	return core.Source{}, nil
 }
 
-func CreateSourceRetvalsFlipped() (error, core.Source) {
+func CreateSourceFlipped() (error, core.Source) {
 	return nil, core.Source{}
 }
 
@@ -42,19 +42,19 @@ func TestOnlySourceExtractIsTaintedInstructionOrder() {
 	core.Sink(s) // want "a source has reached a sink"
 }
 
+func TestOnlySourceExtractIsTaintedFlipped() {
+	err, s := CreateSourceFlipped()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
 func TestOnlySourceExtractIsTaintedInstructionOrderFlipped() {
-	err, s := CreateSourceRetvalsFlipped()
-	core.Sink(s) // want "a source has reached a sink"
-	core.Sink(err)
-}
-
-func TestExtractsFlipped() {
-	err, s := CreateSourceRetvalsFlipped()
+	err, s := CreateSourceFlipped()
 	core.Sink(err)
 	core.Sink(s) // want "a source has reached a sink"
 }
 
-func TestExtractsFromCallWithSourceArg(s core.Source) {
+func TestExtractsFromCallWithSourceArgAreTainted(s core.Source) {
 	str, i, e := TakeSource(s)
 	core.Sink(str) // want "a source has reached a sink"
 	core.Sink(i)   // want "a source has reached a sink"

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -60,3 +60,27 @@ func TestExtractsFromCallWithSourceArgAreTainted(s core.Source) {
 	core.Sink(i)   // want "a source has reached a sink"
 	core.Sink(e)   // want "a source has reached a sink"
 }
+
+func NewSource() (*core.Source, error) {
+	return &core.Source{}, nil
+}
+
+func TestNewSource() {
+	s, err := NewSource()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
+func TestCopy() {
+	s := core.Source{}
+	cpy, err := s.Copy()
+	core.Sink(cpy) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
+func TestCopyPointer() {
+	s := core.Source{}
+	cpy, err := s.CopyPointer()
+	core.Sink(cpy) // want "a source has reached a sink"
+	core.Sink(err)
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extracts
+
+import (
+	"example.com/core"
+)
+
+func CreateSource() (core.Source, error) {
+	return core.Source{}, nil
+}
+
+func CreateSourceRetvalsFlipped() (error, core.Source) {
+	return nil, core.Source{}
+}
+
+func TakeSource(s core.Source) (string, int, interface{}) {
+	return "", 0, nil
+}
+
+func TestOnlySourceExtractIsTainted() {
+	s, err := CreateSource()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
+func TestOnlySourceExtractIsTaintedInstructionOrder() {
+	s, err := CreateSource()
+	core.Sink(err)
+	core.Sink(s) // want "a source has reached a sink"
+}
+
+func TestOnlySourceExtractIsTaintedInstructionOrderFlipped() {
+	err, s := CreateSourceRetvalsFlipped()
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(err)
+}
+
+func TestExtractsFlipped() {
+	err, s := CreateSourceRetvalsFlipped()
+	core.Sink(err)
+	core.Sink(s) // want "a source has reached a sink"
+}
+
+func TestExtractsFromCallWithSourceArg(s core.Source) {
+	str, i, e := TakeSource(s)
+	core.Sink(str) // want "a source has reached a sink"
+	core.Sink(i)   // want "a source has reached a sink"
+	core.Sink(e)   // want "a source has reached a sink"
+}

--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -15,6 +15,7 @@
 package source
 
 import (
+	"go/token"
 	"reflect"
 
 	"github.com/google/go-flow-levee/internal/pkg/config"
@@ -50,10 +51,20 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	if reporting {
 		for _, srcs := range sourceMap {
 			for _, s := range srcs {
-				pass.Reportf(s.node.Pos(), "source identified")
+				// Extracts don't have a registered position in the source code,
+				// so we need to use the position of their related Call.
+				if e, ok := s.node.(*ssa.Extract); ok {
+					report(pass, e.Tuple.Pos())
+					continue
+				}
+				report(pass, s.node.Pos())
 			}
 		}
 	}
 
 	return sourceMap, nil
+}
+
+func report(pass *analysis.Pass, pos token.Pos) {
+	pass.Reportf(pos, "source identified")
 }

--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -52,7 +52,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		for _, srcs := range sourceMap {
 			for _, s := range srcs {
 				// Extracts don't have a registered position in the source code,
-				// so we need to use the position of their related Call.
+				// so we need to use the position of their related Tuple.
 				if e, ok := s.node.(*ssa.Extract); ok {
 					report(pass, e.Tuple.Pos())
 					continue

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -290,6 +290,8 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 					continue
 				}
 
+			// An Extract is used to obtain a value from a call that returns multiple values.
+			// One of the returned values could be a Source.
 			case *ssa.Extract:
 				call := v.Tuple.(*ssa.Call)
 				extractType := call.Call.Signature().Results().At(v.Index).Type()

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -290,15 +290,14 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 					continue
 				}
 
-			// An Extract is used to obtain a value from a call that returns multiple values.
-			// One of the returned values could be a Source.
+			// An Extract is used to obtain a value from an instruction that returns multiple values.
+			// The extracted value could be a Source.
 			case *ssa.Extract:
-				call := v.Tuple.(*ssa.Call)
-				extractType := call.Call.Signature().Results().At(v.Index).Type()
-				if conf.IsSource(utils.Dereference(extractType)) {
+				if t := v.Tuple.Type().(*types.Tuple).At(v.Index).Type(); conf.IsSource(utils.Dereference(t)) {
 					sources = append(sources, New(v, conf))
+					continue
 				}
-				continue
+				break
 
 			// source received from chan
 			case *ssa.UnOp:

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -290,6 +290,14 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 					continue
 				}
 
+			case *ssa.Extract:
+				call := v.Tuple.(*ssa.Call)
+				extractType := call.Call.Signature().Results().At(v.Index).Type()
+				if conf.IsSource(utils.Dereference(extractType)) {
+					sources = append(sources, New(v, conf))
+				}
+				continue
+
 			// source received from chan
 			case *ssa.UnOp:
 				// not a <-chan operation

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -291,13 +291,14 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 				}
 
 			// An Extract is used to obtain a value from an instruction that returns multiple values.
-			// The extracted value could be a Source.
+			// If the Extract is used to get a Pointer, create a Source, otherwise the Source won't
+			// have an Alloc and we'll miss it.
 			case *ssa.Extract:
-				if t := v.Tuple.Type().(*types.Tuple).At(v.Index).Type(); conf.IsSource(utils.Dereference(t)) {
+				t := v.Tuple.Type().(*types.Tuple).At(v.Index).Type()
+				if _, ok := t.(*types.Pointer); ok && conf.IsSource(utils.Dereference(t)) {
 					sources = append(sources, New(v, conf))
-					continue
 				}
-				break
+				continue
 
 			// source received from chan
 			case *ssa.UnOp:

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
@@ -49,9 +49,13 @@ func TestSourceParameters(val Source, ptr *Source) { // want "source identified"
 }
 
 func TestSourceExtracts() {
-	s, err := CreateSource() // want "source identified" "source identified"
-	sp, err := NewSource()   // want "source identified"
-	_, _, _ = s, sp, err
+	s, err := CreateSource()                     // want "source identified"
+	sptr, err := NewSource()                     // want "source identified"
+	mapSource, ok := map[string]Source{}[""]     // want "source identified"
+	mapSourcePtr, ok := map[string]*Source{}[""] // want "source identified"
+	chanSource, ok := <-(make(chan Source))      // want "source identified"
+	chanSourcePtr, ok := <-(make(chan *Source))  // want "source identified"
+	_, _, _, _, _, _, _, _ = s, sptr, mapSource, chanSource, mapSourcePtr, chanSourcePtr, err, ok
 }
 
 func CreateSource() (Source, error) {

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
@@ -47,3 +47,17 @@ func TestSourceDeclarations() {
 func TestSourceParameters(val Source, ptr *Source) { // want "source identified" "source identified"
 
 }
+
+func TestSourceExtracts() {
+	s, err := CreateSource() // want "source identified" "source identified"
+	sp, err := NewSource()   // want "source identified"
+	_, _, _ = s, sp, err
+}
+
+func CreateSource() (Source, error) {
+	return Source{}, nil // want "source identified"
+}
+
+func NewSource() (*Source, error) {
+	return &Source{}, nil // want "source identified"
+}


### PR DESCRIPTION
This PR is a successor to #80. PR #80 addresses false positives caused by traversing from a tainted `Extract` to the other `Extract`s of a `Call`.

This PR addresses `Extract`s not being identified as `Source`s due to being returned by a call that returns a `*Source` instead of a `Source`.

See #80, as well as my comment here: https://github.com/google/go-flow-levee/pull/80#issuecomment-686506245, for additional information.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR