### PR TITLE
Make calls to Operands more direct by passing nil

### DIFF
--- a/internal/pkg/debug/graph/graph.go
+++ b/internal/pkg/debug/graph/graph.go
@@ -88,8 +88,7 @@ func (g *FuncGraph) visit(b *ssa.BasicBlock) {
 }
 
 func (g *FuncGraph) visitOperands(n ssa.Node) {
-	var operands []*ssa.Value
-	operands = n.Operands(operands)
+	operands := n.Operands(nil)
 	if operands == nil {
 		return
 	}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -79,8 +79,7 @@ func (a *Source) dfs(n ssa.Node) {
 		a.visitReferrers(n.Referrers())
 	}
 
-	var operands []*ssa.Value
-	operands = n.Operands(operands)
+	operands := n.Operands(nil)
 	if operands != nil {
 		a.visitOperands(n, operands)
 	}


### PR DESCRIPTION
It always bugged me that we could get the `Referrers` with a simple call, but we had to declare a slice to get the `Operands`. Well, turns out we don't have to.

I find that this reads a bit better. WDYT?

- [x] Tests pass
- [x] Appropriate changes to README are included in PR