### PR TITLE
Add test for sanitization by pointer

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/core/sanitize.go
+++ b/internal/pkg/levee/testdata/src/example.com/core/sanitize.go
@@ -21,3 +21,7 @@ func Sanitize(args ...interface{}) []interface{} {
 func SanitizeSource(s Source) Source {
 	return Source{ID: s.ID}
 }
+
+func SanitizePtr(s *Source) {
+	s.Data = "<redacted>"
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/dominance/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/dominance/tests.go
@@ -43,3 +43,8 @@ func TestNotGuaranteedSanitization(c *core.Source) {
 	}
 	core.Sinkf("Sometimes sanitized: %v", p) // want "a source has reached a sink"
 }
+
+func TestSanitizationByPointer(c core.Source) {
+	core.SanitizePtr(&c)
+	core.Sink(c)
+}


### PR DESCRIPTION
## This PR

This PR adds a test to levee that validates that sanitization by passing a pointer to a source properly prevents future sink calls from being reported.

This test is relevant because in PR #83 I tried to remove the sanitizer package, thinking that it was sufficient to stop traversing when we reach a sanitizer.

## Discussion

With that in mind, we may still want to refine the way sanitization is currently being handled. In particular, consider the following case:
```go
func TestIncorrectSanitization(c core.Source) {
	core.Sanitize(c)
	core.Sink(c) // want "a source has reached a sink"
}
```

In this case, the call to `Sanitizer` is not modifying a pointer, it is operating on a copy of the `Source`. In effect, it is a no-op. It is therefore incorrect to assume that the source is sanitized when it reaches the `Sink`.

Even though this example is rather silly, I think it could conceivably slip through code review, and therefore I think we should handle it. WDYT?

- [x] Tests pass
- [x] Appropriate changes to README are included in PR