### PR TITLE
Add tests for type aliases

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/typealias/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typealias/tests.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inlining
+
+import (
+	"example.com/core"
+)
+
+type Foo core.Source
+
+type Bar = core.Source
+
+func TestTypeDefinition() {
+	core.Sink(Foo{})
+}
+
+func TestTypeAlias() {
+	core.Sink(Bar{}) // want "a source has reached a sink"
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/typealias/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typealias/tests.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package inlining
+package typealias
 
 import (
 	"example.com/core"

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
@@ -41,15 +41,15 @@ func TestSourceDeclarations() {
 	var ptr *Source
 	// We do want a "source identified" here.
 	// ptr does not get optimized out because it gets assigned.
-	ptr = &Source{}                                      // want "source identified"
-	newPtr := new(Source)                                // want "source identified"
-	ptrToDeclZero := &Source{}                           // want "source identified"
-	ptrToDeclPopulated := &Source{Data: "secret", ID: 1} // want "source identified"
+	ptr = &Source{}                                       // want "source identified"
+	newPtr := new(Source)                                 // want "source identified"
+	ptrToDeclZero := &Source{}                            // want "source identified"
+	ptrToDeclPopulataed := &Source{Data: "secret", ID: 1} // want "source identified"
 
 	alias := Alias{} // want "source identified"
 	def := Definition{}
 
-	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulated, alias, def)
+	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulataed, alias, def)
 }
 
 // A report should be emitted for each parameter.

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
@@ -20,6 +20,9 @@ type Source struct {
 	ID   int    // public
 }
 
+// source alias
+type Alias = Source
+
 // This function allows us to consume multiple arguments in a single line so this file can compile
 func noop(args ...interface{}) {}
 
@@ -35,12 +38,14 @@ func TestSourceDeclarations() {
 	var ptr *Source
 	// We do want a "source identified" here.
 	// ptr does not get optimized out because it gets assigned.
-	ptr = &Source{}                                       // want "source identified"
-	newPtr := new(Source)                                 // want "source identified"
-	ptrToDeclZero := &Source{}                            // want "source identified"
-	ptrToDeclPopulataed := &Source{Data: "secret", ID: 1} // want "source identified"
+	ptr = &Source{}                                      // want "source identified"
+	newPtr := new(Source)                                // want "source identified"
+	ptrToDeclZero := &Source{}                           // want "source identified"
+	ptrToDeclPopulated := &Source{Data: "secret", ID: 1} // want "source identified"
 
-	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulataed)
+	alias := Alias{} // want "source identified"
+
+	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulated, alias)
 }
 
 // A report should be emitted for each parameter.

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/test.go
@@ -20,8 +20,11 @@ type Source struct {
 	ID   int    // public
 }
 
-// source alias
+// type alias
 type Alias = Source
+
+// type definition where the underlying type is a Source
+type Definition Source
 
 // This function allows us to consume multiple arguments in a single line so this file can compile
 func noop(args ...interface{}) {}
@@ -44,8 +47,9 @@ func TestSourceDeclarations() {
 	ptrToDeclPopulated := &Source{Data: "secret", ID: 1} // want "source identified"
 
 	alias := Alias{} // want "source identified"
+	def := Definition{}
 
-	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulated, alias)
+	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulated, alias, def)
 }
 
 // A report should be emitted for each parameter.


### PR DESCRIPTION
This PR adds tests showing how type aliases and type definitions are handled.

We already handle type aliases (`type Foo = Source`), and these new tests document that behavior. The tests also show that we do not (currently) handle type definitions where the underlying type is a `Source`, such as `type Foo Source`.

This PR is related to #96.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR