### PR TITLE
Report a position for source extracts

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -79,6 +79,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func report(pass *analysis.Pass, source *source.Source, sink ssa.Node) {
 	var b strings.Builder
 	b.WriteString("a source has reached a sink")
-	fmt.Fprintf(&b, ", source: %v", pass.Fset.Position(source.Node().Pos()))
+	fmt.Fprintf(&b, ", source: %v", pass.Fset.Position(source.Pos()))
 	pass.Reportf(sink.Pos(), b.String())
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/position/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/position/tests.go
@@ -18,14 +18,9 @@ import (
 	"example.com/core"
 )
 
-func TestSourceValue() {
-	s := core.Source{}
-	core.Sink(s) // want "a source has reached a sink, source: .*tests.go:26:2"
-}
-
 func TestSourcePointerExtract() {
 	s, _ := NewSource()
-	core.Sink(s) // want "a source has reached a sink, source: .*tests.go:31:19"
+	core.Sink(s) // want "a source has reached a sink, source: .*tests.go:22:19"
 }
 
 func NewSource() (*core.Source, error) {

--- a/internal/pkg/levee/testdata/src/example.com/tests/position/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/position/tests.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package position
+
+import (
+	"example.com/core"
+)
+
+func TestSourceValue() {
+	s := core.Source{}
+	core.Sink(s) // want "a source has reached a sink, source: .*tests.go:26:2"
+}
+
+func TestSourcePointerExtract() {
+	s, _ := NewSource()
+	core.Sink(s) // want "a source has reached a sink, source: .*tests.go:31:19"
+}
+
+func NewSource() (*core.Source, error) {
+	return &core.Source{}, nil
+}

--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -51,13 +51,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	if reporting {
 		for _, srcs := range sourceMap {
 			for _, s := range srcs {
-				// Extracts don't have a registered position in the source code,
-				// so we need to use the position of their related Tuple.
-				if e, ok := s.node.(*ssa.Extract); ok {
-					report(pass, e.Tuple.Pos())
-					continue
-				}
-				report(pass, s.node.Pos())
+				report(pass, s.Pos())
 			}
 		}
 	}
@@ -66,5 +60,5 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func report(pass *analysis.Pass, pos token.Pos) {
-	pass.Reportf(pos, "source identified")
+	pass.Reportf(pos, "source identified at %s", pass.Fset.Position(pos))
 }

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -49,9 +49,14 @@ type Source struct {
 	lastBlockVisited *ssa.BasicBlock
 }
 
-// Node returns the underlying ssa.Node of the Source.
-func (a *Source) Node() ssa.Node {
-	return a.node
+// Pos returns the token position of the SSA Node associated with the Source.
+func (s *Source) Pos() token.Pos {
+	// Extracts don't have a registered position in the source code,
+	// so we need to use the position of their related Tuple.
+	if e, ok := s.node.(*ssa.Extract); ok {
+		return e.Tuple.Pos()
+	}
+	return s.node.Pos()
 }
 
 // New constructs a Source

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
@@ -14,12 +14,6 @@
 
 package sourcetest
 
-// source container
-type Source struct {
-	Data string // source field
-	ID   int    // public
-}
-
 // This function allows us to consume multiple arguments in a single line so this file can compile
 func noop(args ...interface{}) {}
 
@@ -56,12 +50,4 @@ func TestSourceExtracts() {
 	chanSource, ok := <-(make(chan Source))      // want "source identified"
 	chanSourcePtr, ok := <-(make(chan *Source))  // want "source identified"
 	_, _, _, _, _, _, _, _ = s, sptr, mapSource, chanSource, mapSourcePtr, chanSourcePtr, err, ok
-}
-
-func CreateSource() (Source, error) {
-	return Source{}, nil // want "source identified"
-}
-
-func NewSource() (*Source, error) {
-	return &Source{}, nil // want "source identified"
 }

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/position.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/position.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcetest
+
+func TestSourceValueDeclaration() {
+	s := Source{} // want "source identified at .*position.go:18:2"
+	_ = s
+}
+
+func TestSourcePointerDeclaration() {
+	s := &Source{} // want "source identified at .*position.go:23:14"
+	_ = s
+}
+
+func TestSourceValueParameter(val Source) { // want "source identified at .*position.go:27:31"
+}
+
+func TestSourcePointerParameter(ptr *Source) { // want "source identified at .*position.go:30:33"
+}
+
+func TestSourceValueExtract() {
+	s, _ := CreateSource() // want "source identified at .*position.go:34:2"
+	_ = s
+}
+
+func TestSourcePointerExtract() {
+	s, _ := NewSource() // want "source identified at .*position.go:39:19"
+	_ = s
+}

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/position.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/position.go
@@ -14,28 +14,7 @@
 
 package sourcetest
 
-func TestSourceValueDeclaration() {
-	s := Source{} // want "source identified at .*position.go:18:2"
-	_ = s
-}
-
-func TestSourcePointerDeclaration() {
-	s := &Source{} // want "source identified at .*position.go:23:14"
-	_ = s
-}
-
-func TestSourceValueParameter(val Source) { // want "source identified at .*position.go:27:31"
-}
-
-func TestSourcePointerParameter(ptr *Source) { // want "source identified at .*position.go:30:33"
-}
-
-func TestSourceValueExtract() {
-	s, _ := CreateSource() // want "source identified at .*position.go:34:2"
-	_ = s
-}
-
 func TestSourcePointerExtract() {
-	s, _ := NewSource() // want "source identified at .*position.go:39:19"
+	s, _ := NewSource() // want "source identified at .*position.go:18:19"
 	_ = s
 }

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/source.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/source.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcetest
+
+// source container
+type Source struct {
+	Data string // source field
+	ID   int    // public
+}
+
+func CreateSource() (Source, error) {
+	return Source{}, nil // want "source identified"
+}
+
+func NewSource() (*Source, error) {
+	return &Source{}, nil // want "source identified"
+}


### PR DESCRIPTION
## Context
A recent PR #81 introduced detection of `*Source` values returned by functions that have multiple return values. Such values appear only as `Extract`s in the SSA.

## This PR
The current PR addresses the reporting of such `Source`s. The key point is that `Extract`s do not have a valid `token.Pos`. Their `Pos()` returns `NoPos`, which in reports shows up as: `a source has reached a sink, source: -`. The solution proposed in this PR is to use the position of the `Extract`'s related `Tuple`: `(ssa.Extract).Tuple.Pos()`.

Since it is clearly the `Source`'s responsibility to report its position, I have moved this logic to a method on `Source`.

## Caveats
The main limitation of the proposed solution is that the position that appears in the report is not the position of the variable being declared, which may confuse users a little. That being said, reporting the position of the `Call` (e.g.) that produces the `Source` is certainly better than reporting `-`.

This limitation would become more important if a `Call` were to return more than one `Source`. In such a case it may be difficult for a user to determine precisely which `Source` is involved in the report. However, currently I don't see a way to do it that wouldn't be extremely convoluted. (There may be a way to do it using `Debug` information in the `ssa`, but the `buildssa.Analyzer` does not allow us to do that. The extremely convoluted way to do it would be to identify source-producing calls from the `ast` in advance, then when reporting a `Source` we would find the corresponding call in the `ast` and use the additional information in there, along with knowledge of the function's signature, to determine the position of the `Source` variable being created). 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR