### PR TITLE
Mark type as source if it holds a tagged field

### DIFF
--- a/internal/pkg/sourcetype/testdata/src/sourcetype/test.go
+++ b/internal/pkg/sourcetype/testdata/src/sourcetype/test.go
@@ -21,10 +21,14 @@ type Source struct { // want Source:"source type"
 	ID           int
 }
 
+type SourceContainingTaggedField struct { // want SourceContainingTaggedField:"source type"
+	Tagged string `levee:"source"` // want Tagged:"source field"
+}
+
 type AliasStruct = Source // want AliasStruct:"source type"
 
-// TODO Consider automatic detection of the following types.
-type NamedType Source
+type NamedType Source // want NamedType:"source type"
+
 type SliceContainer []Source
 type ArrayContainer [5]Source
 type MapKeyContainer map[Source]interface{}


### PR DESCRIPTION
## This PR

The current PR is in relation to issue #96.

My original intent was to fix the inconsistent behavior we have right now where a type that holds a tagged field is not considered to be a Source. As a side effect, the way I implemented it gets us some of the way towards supporting identifying `NamedType` as a source type in `type NamedType Source`.

This PR uses the data collected by the `fieldtags` analyzer in the `sourcetype` analyzer in order to mark a `type` containing a tagged field as a `Source`. To do so, the new code scans the fields of the `types.Struct` underlying the type being declared and if it finds a tagged field, declares the type to be a `Source` type.

## Side effects

A side effect of the current implementation is that in `type NamedType Source`, because `Source` has tagged fields, and `NamedType`'s underlying `types.Struct` is the same as the `types.Struct` underlying `Source`, `NamedType` is identified as a source type. `NamedType` would not be identified as a source type if `Source` did not have tagged fields. This behavior may be surprising to users, since we don't handle other cases of `type NamedType Source`.


## Alternative implementation

An alternative implementation would be to export `type`s that hold a tagged field in the `fieldtags` analyzer, and consume those types in the `sourcetype` analyzer. This would circumvent the above-mentioned side effects.

## Discussion

Given all of the above, WDYT? **Is the current approach, with the "side effects" it brings, "ok" to you or should I use a different approach?** 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR