### PR TITLE
Remove dead todo comments in source.go

### DIFF
--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -293,8 +293,6 @@ func sourcesFromParams(fn *ssa.Function, conf classifier) []*Source {
 			if n, ok := t.Elem().(*types.Named); ok && conf.IsSource(n) {
 				sources = append(sources, New(p, conf))
 			}
-			// TODO Handle the case where sources arepassed by value: func(c sourceType)
-			// TODO Handle cases where PII is wrapped in struct/slice/map
 		}
 	}
 	return sources


### PR DESCRIPTION
The first TODO, detecting `Source`s passed by value, is already handled by the code in `sourcesFromBlocks`: a source that is passed by value will have an `Alloc` that points to the parameter.

The second case is unclear, and I believe as a TODO it is unhelpful. We currently have some handling of sources in collections. I believe the remainder of what the TODO could be pointing to is covered by issues #96 and #97.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR