### PR TITLE
Remove unnecessary reporting flag

### DIFF
--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -35,10 +35,6 @@ var Analyzer = &analysis.Analyzer{
 	ResultType: reflect.TypeOf(new(ResultType)).Elem(),
 }
 
-// When reporting is true, report findings to pass.Report.
-// TODO This should be a flag passable to the common config.
-var reporting bool
-
 func run(pass *analysis.Pass) (interface{}, error) {
 	ssaInput := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
 	conf, err := config.ReadConfig()
@@ -48,17 +44,15 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	sourceMap := identify(conf, ssaInput)
 
-	if reporting {
-		for _, srcs := range sourceMap {
-			for _, s := range srcs {
-				// Extracts don't have a registered position in the source code,
-				// so we need to use the position of their related Tuple.
-				if e, ok := s.node.(*ssa.Extract); ok {
-					report(pass, e.Tuple.Pos())
-					continue
-				}
-				report(pass, s.node.Pos())
+	for _, srcs := range sourceMap {
+		for _, s := range srcs {
+			// Extracts don't have a registered position in the source code,
+			// so we need to use the position of their related Tuple.
+			if e, ok := s.node.(*ssa.Extract); ok {
+				report(pass, e.Tuple.Pos())
+				continue
 			}
+			report(pass, s.node.Pos())
 		}
 	}
 

--- a/internal/pkg/source/analyzer_test.go
+++ b/internal/pkg/source/analyzer_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestSourceAnalysis(t *testing.T) {
-	reporting = true
-
 	testdata := analysistest.TestData()
 	if err := config.FlagSet.Set("config", testdata+"/src/analyzertest/test-config.json"); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Remove an unnecessary reporting flag associated with a TODO item.

Relevant discussion: https://github.com/google/go-flow-levee/pull/39#discussion_r468885853

- [x] Tests pass
- [x] Appropriate changes to README are included in PR