### PR TITLE
Do not visit instructions that are not reachable from source

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
@@ -18,6 +18,7 @@ import (
 	"example.com/core"
 )
 
+// This type should *not* be identified as a Source.
 type key struct {
 	name string
 }
@@ -33,6 +34,7 @@ func newKey() *key {
 }
 
 func TestDoesNotReachSinkAfterSourceThroughValueCreatedBeforeSource() {
+	// Taint should not propagate to this value.
 	k := newKey()
 
 	_ = map[string]core.Source{}[k.name]
@@ -41,6 +43,7 @@ func TestDoesNotReachSinkAfterSourceThroughValueCreatedBeforeSource() {
 }
 
 func TestDoesNotReachSinkInIfBeforeSourceThroughValueCreatedBeforeSource() {
+	// Taint should not propagate to this value.
 	k := newKey()
 
 	if true {

--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
@@ -28,7 +28,7 @@ func (k *key) Name() string {
 
 func newKey() *key {
 	return &key{
-		name: "source",
+		name: "",
 	}
 }
 

--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callorder
+
+import (
+	"example.com/core"
+)
+
+type key struct {
+	name string
+}
+
+func (k *key) Name() string {
+	return k.name
+}
+
+func newKey() *key {
+	return &key{
+		name: "source",
+	}
+}
+
+func TestDoesNotReachSinkAfterSourceThroughValueCreatedBeforeSource() {
+	k := newKey()
+
+	_ = map[string]core.Source{}[k.name]
+
+	core.Sink(k.Name())
+}
+
+func TestDoesNotReachSinkInIfBeforeSourceThroughValueCreatedBeforeSource() {
+	k := newKey()
+
+	if true {
+		core.Sink(k.Name())
+	}
+
+	_ = map[string]core.Source{}[k.name]
+}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -75,15 +75,16 @@ func New(in ssa.Node, config classifier) *Source {
 // While traversing the graph we also look for potential sanitizers of this Source.
 // If the Source passes through a sanitizer, dfs does not continue through that Node.
 func (s *Source) dfs(n ssa.Node) {
+	instr, ok := n.(ssa.Instruction)
+	if ok && !s.reachableFromSource(instr) {
+		return
+	}
+
+	if ok {
+		s.record(instr)
+	}
 	s.preOrder = append(s.preOrder, n)
 	s.marked[n.(ssa.Node)] = true
-
-	if instr, ok := n.(ssa.Instruction); ok {
-		s.record(instr)
-		if !s.reachableFromSource(instr) {
-			return
-		}
-	}
 
 	s.visitReferrers(n)
 

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -170,7 +170,7 @@ func (s *Source) referrersToVisit(n ssa.Node) (referrers []ssa.Instruction) {
 }
 
 func (s *Source) reachableFromSource(target ssa.Instruction) bool {
-	// If the Source isn't an instruction, be conservative and
+	// If the Source isn't produced by an instruction, be conservative and
 	// assume the target instruction is reachable.
 	sInstr, ok := s.node.(ssa.Instruction)
 	if !ok {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -75,12 +75,10 @@ func New(in ssa.Node, config classifier) *Source {
 // While traversing the graph we also look for potential sanitizers of this Source.
 // If the Source passes through a sanitizer, dfs does not continue through that Node.
 func (s *Source) dfs(n ssa.Node) {
-	instr, ok := n.(ssa.Instruction)
-	if ok && !s.reachableFromSource(instr) {
-		return
-	}
-
-	if ok {
+	if instr, ok := n.(ssa.Instruction); ok {
+		if !s.reachableFromSource(instr) {
+			return
+		}
 		s.record(instr)
 	}
 	s.preOrder = append(s.preOrder, n)

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -177,6 +177,8 @@ func (s *Source) reachableFromSource(target ssa.Instruction) bool {
 		return true
 	}
 
+	// If these calls fail, be conservative and assume the target
+	// instruction is reachable.
 	sIndex, sOk := indexInBlock(sInstr)
 	targetIndex, targetOk := indexInBlock(target)
 	if !sOk || !targetOk {


### PR DESCRIPTION
This PR implements a fix that addresses incorrect reports produced when running `levee` on `kubernetes`.

The incorrect reports were caused by traversing to instructions unreachable from the `Source` from which the traversal originated. Here is an example:
```go
func TestDoesNotReachSinkAfterSourceThroughValueCreatedBeforeSource() {
	k := newKey()

	_ = map[string]core.Source{}[k.name]

	core.Sink(k.Name())
}
```

The incorrect report in this case is caused by the following traversal flow: `map[string]core.Source{}[k.name] --> k.name --> k --> k.Name() --> core.Sink` (the `Source` value is produced by the map lookup). Clearly, the `Source` value in this example cannot taint `k`, and in general we should avoid traversing to instructions that are not reachable from the `Source`.

There are some subtleties involved in the above test case, that are required for the incorrect behavior to emerge. First, `k` has to be a pointer returned from a function. That way, it does not have an `Alloc`. If it did have an `Alloc`, then we would not traverse through it (see `source.go:245`).  Second, for similar reasons, we have to access `k`'s `name` field via `k.Name()`.

The assignment to `_` is simply to avoid compiler warnings about unused variables. Interestingly, even though the value returned from the lookup is unusable because of the blank identifier, it still shows up in the SSA.

I have included a second test case:
```go
func TestDoesNotReachSinkInIfBeforeSourceThroughValueCreatedBeforeSource() {
	k := newKey()

	if true {
		core.Sink(k.Name())
	}

	_ = map[string]core.Source{}[k.name]
}
```
This case more closely mirrors the cases encountered on `kubernetes`. The key nuance here is that the call to `core.Sink` is in a different block from the map lookup. Due to the incorrect traversal order described earlier (which is largely the same here), our usual check for calls that are not reachable from the previous instruction (see `source.go:146`) wasn't stopping the traversal.

All of these subtleties and nuances are making me realize that our traversal code is fairly convoluted. I will seek to address this in future PRs. (For context, at present it is not possible to remove any of the other checks we have in place without causing tests to fail).

- [x] Tests pass
- [x] Appropriate changes to README are included in PR