### PR TITLE
Fix traversal bugs

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/colocation.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/colocation.go
@@ -40,7 +40,7 @@ func fail(x interface{}) error {
 	return nil
 }
 
-func taintColocated(a interface{}, b interface{}) {
+func taintColocated(a, b interface{}) {
 }
 
 func newInnocuous() *core.Innocuous {

--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/colocation.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/colocation.go
@@ -36,6 +36,20 @@ func TestTaintedColocatedArgumentReachesSinkThatFollowsColocation() {
 	}
 }
 
+func TestAvoidingIncorrectPropagationFromColocationDoesNotPreventCorrectReport() {
+	source := newSource()
+
+	cp, err := copy(source)
+	if err != nil {
+		core.Sink(err) // want "a source has reached a sink"
+	}
+
+	if true {
+		innoc := newInnocuous()
+		taintColocated(cp, innoc)
+	}
+}
+
 func fail(x interface{}) error {
 	return nil
 }
@@ -45,4 +59,12 @@ func taintColocated(a, b interface{}) {
 
 func newInnocuous() *core.Innocuous {
 	return &core.Innocuous{}
+}
+
+func newSource() *core.Source {
+	return &core.Source{}
+}
+
+func copy(a interface{}) (interface{}, error) {
+	return nil, nil
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/colocation.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/colocation.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callorder
+
+import (
+	"example.com/core"
+)
+
+func TestTaintedColocatedArgumentDoesNotReachSinkThatPrecedesColocation() {
+	s := core.Source{}
+	i := newInnocuous()
+	if err := fail(i); err != nil {
+		core.Sink(err)
+	}
+	taintColocated(s, i)
+}
+
+func TestTaintedColocatedArgumentReachesSinkThatFollowsColocation() {
+	s := core.Source{}
+	i := newInnocuous()
+	taintColocated(s, i)
+	if err := fail(i); err != nil {
+		core.Sink(err) // want "a source has reached a sink"
+	}
+}
+
+func fail(x interface{}) error {
+	return nil
+}
+
+func taintColocated(a interface{}, b interface{}) {
+}
+
+func newInnocuous() *core.Innocuous {
+	return &core.Innocuous{}
+}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -91,7 +91,12 @@ func (s *Source) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBl
 			!s.canReach(lastBlockVisited, ib) {
 			return
 		}
-		s.record(instr, mirCopy, &lastBlockVisited)
+
+		b := instr.Block()
+		if i, ok := indexInBlock(instr); ok && mirCopy[b] < i {
+			mirCopy[b] = i
+		}
+		lastBlockVisited = b
 	}
 	s.preOrder = append(s.preOrder, n)
 	s.marked[n] = true
@@ -101,18 +106,6 @@ func (s *Source) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBl
 	operands := n.Operands(nil)
 	if operands != nil {
 		s.visitOperands(n, operands, mirCopy, lastBlockVisited)
-	}
-}
-
-func (s *Source) record(target ssa.Instruction, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited **ssa.BasicBlock) {
-	b := target.Block()
-	*lastBlockVisited = b
-	i, ok := indexInBlock(target)
-	if !ok {
-		return
-	}
-	if maxInstrReached[b] < i {
-		maxInstrReached[b] = i
 	}
 }
 

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -40,13 +40,11 @@ type classifier interface {
 // its referrers.
 // Source.sanitized notes sanitizer calls that sanitize this Source
 type Source struct {
-	node             ssa.Node
-	marked           map[ssa.Node]bool
-	preOrder         []ssa.Node
-	sanitizers       []*sanitizer.Sanitizer
-	config           classifier
-	maxInstrReached  map[*ssa.BasicBlock]int
-	lastBlockVisited *ssa.BasicBlock
+	node       ssa.Node
+	marked     map[ssa.Node]bool
+	preOrder   []ssa.Node
+	sanitizers []*sanitizer.Sanitizer
+	config     classifier
 }
 
 // Pos returns the token position of the SSA Node associated with the Source.
@@ -62,57 +60,61 @@ func (s *Source) Pos() token.Pos {
 // New constructs a Source
 func New(in ssa.Node, config classifier) *Source {
 	s := &Source{
-		node:            in,
-		marked:          make(map[ssa.Node]bool),
-		config:          config,
-		maxInstrReached: map[*ssa.BasicBlock]int{},
+		node:   in,
+		marked: make(map[ssa.Node]bool),
+		config: config,
 	}
-	s.dfs(in)
+	s.dfs(in, map[*ssa.BasicBlock]int{}, nil)
 	return s
 }
 
 // dfs performs Depth-First-Search on the def-use graph of the input Source.
 // While traversing the graph we also look for potential sanitizers of this Source.
 // If the Source passes through a sanitizer, dfs does not continue through that Node.
-func (s *Source) dfs(n ssa.Node) {
+func (s *Source) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+	mirCopy := map[*ssa.BasicBlock]int{}
+	for m, i := range maxInstrReached {
+		mirCopy[m] = i
+	}
+
 	if instr, ok := n.(ssa.Instruction); ok {
 		if !s.reachableFromSource(instr) {
 			return
 		}
 		// If the referrer is in a different block from the one we last visited,
 		// and it can't be reached from the block we are visiting, then stop visiting.
-		if ib := instr.Block(); s.lastBlockVisited != nil &&
-			ib != s.lastBlockVisited &&
-			!s.canReach(s.lastBlockVisited, ib) {
+		if ib := instr.Block(); lastBlockVisited != nil &&
+			ib != lastBlockVisited &&
+			!s.canReach(lastBlockVisited, ib) {
 			return
 		}
-		s.record(instr)
+		s.record(instr, mirCopy, &lastBlockVisited)
 	}
 	s.preOrder = append(s.preOrder, n)
 	s.marked[n.(ssa.Node)] = true
 
-	s.visitReferrers(n)
+	s.visitReferrers(n, mirCopy, lastBlockVisited)
 
 	operands := n.Operands(nil)
 	if operands != nil {
-		s.visitOperands(n, operands)
+		s.visitOperands(n, operands, mirCopy, lastBlockVisited)
 	}
 }
 
-func (s *Source) record(target ssa.Instruction) {
+func (s *Source) record(target ssa.Instruction, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited **ssa.BasicBlock) {
 	b := target.Block()
-	s.lastBlockVisited = b
+	*lastBlockVisited = b
 	i, ok := indexInBlock(target)
 	if !ok {
 		return
 	}
-	if s.maxInstrReached[b] < i {
-		s.maxInstrReached[b] = i
+	if maxInstrReached[b] < i {
+		maxInstrReached[b] = i
 	}
 }
 
-func (s *Source) visitReferrers(n ssa.Node) {
-	referrers := s.referrersToVisit(n)
+func (s *Source) visitReferrers(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+	referrers := s.referrersToVisit(n, maxInstrReached)
 
 	for _, r := range referrers {
 		if s.marked[r.(ssa.Node)] {
@@ -126,14 +128,14 @@ func (s *Source) visitReferrers(n ssa.Node) {
 			}
 		}
 
-		s.dfs(r.(ssa.Node))
+		s.dfs(r.(ssa.Node), maxInstrReached, lastBlockVisited)
 	}
 }
 
 // referrersToVisit produces a filtered list of Referrers for an ssa.Node.
 // Specifically, we want to avoid referrers that shouldn't be visited, e.g.
 // because they would not be reachable in an actual execution of the program.
-func (s *Source) referrersToVisit(n ssa.Node) (referrers []ssa.Instruction) {
+func (s *Source) referrersToVisit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int) (referrers []ssa.Instruction) {
 	if n.Referrers() == nil {
 		return
 	}
@@ -151,7 +153,7 @@ func (s *Source) referrersToVisit(n ssa.Node) (referrers []ssa.Instruction) {
 			if !ok {
 				continue
 			}
-			if i < s.maxInstrReached[r.Block()] {
+			if i < maxInstrReached[r.Block()] {
 				continue
 			}
 		}
@@ -215,7 +217,7 @@ func (s *Source) canReach(start *ssa.BasicBlock, dest *ssa.BasicBlock) bool {
 	return false
 }
 
-func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value) {
+func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
 	_, visitingFromExtract := n.(*ssa.Extract)
 
 	for _, o := range operands {
@@ -245,7 +247,7 @@ func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value) {
 				return
 			}
 		}
-		s.dfs(n)
+		s.dfs(n, maxInstrReached, lastBlockVisited)
 	}
 }
 


### PR DESCRIPTION
## Context

This PR implements fixes for bugs that I have found when running the tool on `kubernetes`. I am done investigating the reports so there will be no more bug fixes originating from this investigation.

## The bugs

This PR fixes 2 distinct bugs related to traversal:
1. Visiting unreachable `Operands`.
2. Using global state to track `maxInstructionReached` and `lastVisitedBlock`.

## 1. Visiting unreachable `Operands`

When considering which referrers to visit, we avoid referrers that are not reachable from the current instruction. We do not do this for operands, however, which can lead to incorrect reports on code such as this:
```go
func TestTaintedColocatedArgumentDoesNotReachSinkThatPrecedesColocation() {
	s := core.Source{}
	i := newInnocuous()
	if err := fail(i); err != nil {
		core.Sink(err) // A REPORT IS INCORRECTLY PRODUCED HERE
	}
	taintColocated(s, i)
}
```
The report in the above case is caused by the following taint flow: `s → taintColocated(...) → i → fail(...) → err → core.Sink(...)`. Taint propagates to `i` because it is an `Operand` of the call to `taintColocated`.

 To fix this bug, I have moved the reachability check into `source.go:dfs` so that it will be done for every `ssa.Node`, which includes `Operands`, not just `Referrers`.

## 2. Using global state to track `maxInstructionReached` and `lastVisitedBlock`

These values need to evolve independently for each traversal path in the SSA graph. Using global values means that what happens in one traversal path can influence what happens in a different traversal path, which is clearly wrong. I have not been able to write a test case demonstrating the incorrect behavior. I believe that writing such a test is not a simple task, and the resulting test is likely to be difficult to understand. Here is a (slightly) simplified example of a real error case from `kubernetes`, in `cmd/kubermark/hollow_node.go`:

```go
func run(config *hollowNodeConfig) {
	clientConfig, err := config.createClientConfigFromFile()
	if err != nil {
		klog.Fatalf("Failed to create a ClientConfig: %v. Exiting.", err)
	}

	client, err := clientset.NewForConfig(clientConfig)
	if err != nil {
		klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err) // even though this error does not contain sensitive information, we want a report here because currently levee has no way to determine that
	}

	if config.Morph == "kubelet" {
		f, c := kubemark.GetHollowKubeletConfig(config.createHollowKubeletOptions())

		heartbeatClientConfig := *clientConfig
		heartbeatClient, err := clientset.NewForConfig(&heartbeatClientConfig)
		if err != nil {
			klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err) // even though this error does not contain sensitive information, we want a report here because currently levee has no way to determine that
		}

		endpoint, err := fakeremote.GenerateEndpoint()
		if err != nil {
			klog.Fatalf("Failed to generate fake endpoint %v.", err) // WE DO NOT WANT A REPORT HERE, ERR SHOULD NOT BE TAINTED
		}
		fakeRemoteRuntime := fakeremote.NewFakeRemoteRuntime()
		if err = fakeRemoteRuntime.Start(endpoint); err != nil {
			klog.Fatalf("Failed to start fake runtime %v.", err)
		}
		defer fakeRemoteRuntime.Stop()
		runtimeService, err := remote.NewRemoteRuntimeService(endpoint, 15*time.Second)
		if err != nil {
			klog.Fatalf("Failed to init runtime service %v.", err)  // WE DO NOT WANT A REPORT HERE, ERR SHOULD NOT BE TAINTED
		}

		hollowKubelet := kubemark.NewHollowKubelet(
			f, c,
			client,
			heartbeatClient,
			nil,
			fakeRemoteRuntime.ImageService,
			runtimeService,
			nil,
		)
		hollowKubelet.Run()
	}
}
```

The two lines producing incorrect reports are indicated by comments. The incorrect reports are due to taint incorrectly propagating from colocation in the call to `kubemark.NewHollowKubelet`.

Fixing that bug (propagating to `Operands` we shouldn't propagate to) causes the *correct* reports to disappear. The precise sequence of steps that causes this is not clear, but tracking state per-traversal-path rather than globally (per-source)  fixes it. In fact, just tracking the `lastVisitedBlock` properly fixes the bug, but in the interest of preventing future issues I have also fixed the code involving `maxInstructionReached`.

## The commits

Since this PR fixes 2 bugs, it should perhaps be 2 PR's. However, I believe that the 2 bugs are closely related, and both fixes are required to exhibit correct behavior on the above-mentioned case that prompted this PR, so having just 1 PR makes sense. (If you disagree, please let me know and I will split the PR).

In the interest of making the PR easier to review, I have split the changes into 3 commits:
1. add tests
2. fix operands bug
3. fix global state bug

- [x] Tests pass
- [x] Appropriate changes to README are included in PR