### PR TITLE
Fix: skip to next Operand instead of skipping all remaining Operands

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colocation
+
+import (
+	"example.com/core"
+)
+
+func TestTaintIsPropagatedToOperandAfterNonArrayAlloc(s core.Source, ip *core.Innocuous) {
+	i := core.Innocuous{}
+	taintColocated(s, &i, ip)
+	core.Sink(ip) // want "a source has reached a sink"
+}
+
+func taintColocated(s core.Source, i *core.Innocuous, c interface{}) interface{} {
+	return nil
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/colocation/tests.go
@@ -24,6 +24,6 @@ func TestTaintIsPropagatedToOperandAfterNonArrayAlloc(s core.Source, ip *core.In
 	core.Sink(ip) // want "a source has reached a sink"
 }
 
-func taintColocated(s core.Source, i *core.Innocuous, c interface{}) interface{} {
+func taintColocated(a interface{}, i *core.Innocuous, c interface{}) interface{} {
 	return nil
 }

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -243,7 +243,7 @@ func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value) {
 		// is being placed into an array, slice or varags, so we do need to keep visiting.
 		if al, isAlloc := (*o).(*ssa.Alloc); isAlloc {
 			if _, isArray := utils.Dereference(al.Type()).(*types.Array); !isArray {
-				return
+				continue
 			}
 		}
 		s.dfs(n)


### PR DESCRIPTION
This PR fixes a bug in the way visiting a `Call`'s `Operands` works. Currently we `return` when we meet an `Operand` that is an `Alloc` that we don't want to visit. What we actually want to do is `continue` to the next `Operand`.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR