### PR TITLE
Debug: Render CFG

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ In the `dot` output:
 * **Diamond**-shaped nodes represent `ssa.Node`s that are only `ssa.Instruction`s
 * **Ellipse**-shaped nodes represent `ssa.Node`s that are either only `ssa.Value`s, or are `ssa.Member`s.
 
+The function's control-flow graph (CFG) is also produced and written in a file named `<function-name>-cfg.dot`.
+
 ## Source Code Headers
 
 Every file containing source code must include copyright and license

--- a/internal/pkg/debug/debug.go
+++ b/internal/pkg/debug/debug.go
@@ -34,6 +34,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		pkgName := f.Pkg.Pkg.Name()
 		dump.SSA(pkgName, f)
 		dump.DOT(pkgName, f)
+		dump.CFG(pkgName, f)
 	}
 
 	return nil, nil

--- a/internal/pkg/debug/dump/dump.go
+++ b/internal/pkg/debug/dump/dump.go
@@ -37,6 +37,11 @@ func DOT(fileName string, f *ssa.Function) {
 	save(fileName, f.Name(), render.DOT(f), "dot")
 }
 
+// CFG dumps DOT source representing the function's control flow graph (CFG) to a file.
+func CFG(fileName string, f *ssa.Function) {
+	save(fileName, f.Name()+"-cfg", render.CFG(f), "dot")
+}
+
 func save(fileName, funcName, s, ending string) {
 	baseName := strings.TrimSuffix(fileName, ".go")
 	outFile := fmt.Sprintf("%s_%s.%s", baseName, funcName, ending)

--- a/internal/pkg/debug/render/cfg.go
+++ b/internal/pkg/debug/render/cfg.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// CFG renders DOT source representing the function's control flow graph (CFG).
+func CFG(f *ssa.Function) string {
+	blockIndex := map[*ssa.BasicBlock]int{}
+	for i, b := range f.Blocks {
+		blockIndex[b] = i
+	}
+
+	var b strings.Builder
+	b.WriteString("digraph {\n")
+	for _, block := range f.Blocks {
+		b.WriteString(fmt.Sprintf("\t%q\n", blockLabel(block, blockIndex)))
+		for _, succ := range block.Succs {
+			b.WriteString(fmt.Sprintf("\t%q -> %q;\n", blockLabel(block, blockIndex), blockLabel(succ, blockIndex)))
+		}
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+func blockLabel(b *ssa.BasicBlock, blockIndex map[*ssa.BasicBlock]int) string {
+	return fmt.Sprintf("%d %s", blockIndex[b], b.Comment)
+}


### PR DESCRIPTION
This PR adds CFG rendering to our debugging tools.

Being able to visualize the CFG is helpful for understanding multi-block functions.

For the following function:
```go
func TestTaintInNestedIfBeforeSink(s core.Source, w io.Writer) {
	if true {
		if true {
			fmt.Fprintf(w, "%v", s)
			core.Sink(w) // want "a source has reached a sink"
		}
		core.Sink(w) // want "a source has reached a sink"
	}
	core.Sink(w) // want "a source has reached a sink"
}
```

The output is:
![image](https://user-images.githubusercontent.com/28677454/94044685-794c7200-fd9c-11ea-9b3f-da62fb7eb3a6.png)

Importantly, the numbers in the rendering match the numbers in the SSA dump.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR