### PR TITLE
Use reflect.StructTag.Get in fieldtag logic.

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 	"go/types"
 	"io/ioutil"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -54,13 +55,10 @@ type fieldTagMatcher struct {
 // IsSourceFieldTag determines whether a field tag made up of a key and value
 // is a Source.
 func (c Config) IsSourceFieldTag(tag string) bool {
-	// tag is the entire, quote-wrapped string, e.g. "`levee:...`"
-	// Trim for use by reflect.StructTag
-	if len(tag) < 2 {
-		return false
+	if unq, err := strconv.Unquote(tag); err == nil {
+		tag = unq
 	}
-
-	st := reflect.StructTag(tag[1 : len(tag)-1])
+	st := reflect.StructTag(tag)
 
 	// built in
 	if st.Get("levee") == "source" {

--- a/internal/pkg/config/fieldtags_test.go
+++ b/internal/pkg/config/fieldtags_test.go
@@ -30,41 +30,36 @@ func TestFieldTagsIdentification(t *testing.T) {
 
 	cases := []struct {
 		desc string
-		key  string
-		val  string
+		tag  string
 		want bool
 	}{
 		{
 			"built-in field tag",
-			"levee",
-			"source",
+			"`levee:\"source\"`",
 			true,
 		},
 		{
 			"custom field tag",
-			"example",
-			"sensitive",
+			"`example:\"sensitive\"`",
 			true,
 		},
 		{
 			"different tag key",
-			"notexample",
-			"sensitive",
+			"`notexample:\"sensitive\"`",
 			false,
 		},
 		{
 			"different tag value",
-			"example",
-			"notsensitive",
+			"`example:\"notsensitive\"`",
 			false,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := config.IsSourceFieldTag(tt.key, tt.val)
+			got := config.IsSourceFieldTag(tt.tag)
 			if got != tt.want {
-				t.Errorf("config.IsSourceFieldTag(%q, %q) == %v, want %v", tt.key, tt.val, got, tt.want)
+				t.Errorf("config.IsSourceFieldTag(%q) == %v, want %v", tt.tag, got, tt.want)
 			}
 		})
 	}

--- a/internal/pkg/config/fieldtags_test.go
+++ b/internal/pkg/config/fieldtags_test.go
@@ -53,6 +53,11 @@ func TestFieldTagsIdentification(t *testing.T) {
 			"`example:\"notsensitive\"`",
 			false,
 		},
+		{
+			"escaped tag accepted",
+			`"levee:\"source\""`,
+			true,
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/pkg/config/fieldtags_test.go
+++ b/internal/pkg/config/fieldtags_test.go
@@ -58,6 +58,36 @@ func TestFieldTagsIdentification(t *testing.T) {
 			`"levee:\"source\""`,
 			true,
 		},
+		{
+			"multiple values, no target",
+			"`example:\"foo,bar,baz\"`",
+			false,
+		},
+		{
+			"multiple values, with target",
+			"`example:\"foo,sensitive,bar\"`",
+			true,
+		},
+		{
+			"multiple key value sets, no target",
+			"`foo:\"bar,baz\" example:\"foo,sensitive,bar\" fizz:\"bang\"`",
+			true,
+		},
+		{
+			"multiple, no target",
+			"`foo:\"bar,baz\" example:\"foo,sensitive,bar\"` fizz:\"bang\"",
+			true,
+		},
+		{
+			"empty",
+			"",
+			false,
+		},
+		{
+			"malformed",
+			"`noEndQuote:\"malform",
+			false,
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/pkg/config/fieldtags_test.go
+++ b/internal/pkg/config/fieldtags_test.go
@@ -70,11 +70,11 @@ func TestFieldTagsIdentification(t *testing.T) {
 		},
 		{
 			"multiple key value sets, no target",
-			"`foo:\"bar,baz\" example:\"foo,sensitive,bar\" fizz:\"bang\"`",
-			true,
+			"`foo:\"bar,baz\" example:\"foo,bar,baz\" fizz:\"bang\"`",
+			false,
 		},
 		{
-			"multiple, no target",
+			"multiple key value sets, with target",
 			"`foo:\"bar,baz\" example:\"foo,sensitive,bar\"` fizz:\"bang\"",
 			true,
 		},

--- a/internal/pkg/fieldtags/analyzer.go
+++ b/internal/pkg/fieldtags/analyzer.go
@@ -71,14 +71,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 		for _, f := range (*s).Fields.List {
-			tags := extractTags(f)
-			isTaggedField := false
-			for _, ft := range tags {
-				if conf.IsSourceFieldTag(ft.key, ft.val) {
-					isTaggedField = true
-				}
-			}
-			if !isTaggedField || len(f.Names) == 0 {
+			if f.Tag == nil || len(f.Names) == 0 || !conf.IsSourceFieldTag(f.Tag.Value) {
 				continue
 			}
 			fNames := make([]string, len(f.Names))

--- a/internal/pkg/fieldtags/analyzer_test.go
+++ b/internal/pkg/fieldtags/analyzer_test.go
@@ -39,9 +39,9 @@ func TestFieldTagsAnalysis(t *testing.T) {
 
 	want := []string{
 		"password",
-		"another",
 		"creds",
 		"secret",
+		"another",
 		"hasCustomFieldTag",
 		"hasTagWithMultipleValues",
 	}

--- a/internal/pkg/fieldtags/analyzer_test.go
+++ b/internal/pkg/fieldtags/analyzer_test.go
@@ -39,6 +39,7 @@ func TestFieldTagsAnalysis(t *testing.T) {
 
 	want := []string{
 		"password",
+		"another",
 		"creds",
 		"secret",
 		"hasCustomFieldTag",

--- a/internal/pkg/fieldtags/analyzer_test.go
+++ b/internal/pkg/fieldtags/analyzer_test.go
@@ -41,7 +41,6 @@ func TestFieldTagsAnalysis(t *testing.T) {
 		"password",
 		"creds",
 		"secret",
-		"another",
 		"hasCustomFieldTag",
 		"hasTagWithMultipleValues",
 	}

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,11 +15,12 @@
 package fieldtags
 
 type Person struct {
-	password, creds          string `levee:"source"`               // want "tagged field: password, creds"
-	secret                   string `json:"secret" levee:"source"` // want "tagged field: secret"
-	hasCustomFieldTag        string `example:"sensitive"`          // want "tagged field: hasCustomFieldTag"
-	hasTagWithMultipleValues string `example:"sensitive,verbose"`  // want "tagged field: hasTagWithMultipleValues"
-	name                     string `some_key:"non_secret"`
-	spaceAfterFinalQuote     string `key:"value" `
+	password, creds          string      `levee:"source"`               // want "tagged field: password, creds"
+	secret                   string      `json:"secret" levee:"source"` // want "tagged field: secret"
+	another                  interface{} "levee:\"source\""             // want "tagged field: another"
+	hasCustomFieldTag        string      `example:"sensitive"`          // want "tagged field: hasCustomFieldTag"
+	hasTagWithMultipleValues string      `example:"sensitive,verbose"`  // want "tagged field: hasTagWithMultipleValues"
+	name                     string      `some_key:"non_secret"`
+	spaceAfterFinalQuote     string      `key:"value" `
 	someNotTaggedField       int
 }

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,11 +15,11 @@
 package fieldtags
 
 type Person struct {
-	password, creds          string      `levee:"source"`                   // want "tagged field: password, creds"
-	secret                   string      `json:"secret" levee:"source"`     // want "tagged field: secret"
-	another                  interface{} "levee:\"source\""                 // want "tagged field: another"
-	hasCustomFieldTag        string      `example:"sensitive"`              // want "tagged field: hasCustomFieldTag"
-	hasTagWithMultipleValues string      `example:"sensitive,verbose,long"` // want "tagged field: hasTagWithMultipleValues"
+	password, creds          string      `levee:"source"`               // want "tagged field: password, creds"
+	secret                   string      `json:"secret" levee:"source"` // want "tagged field: secret"
+	another                  interface{} "levee:\"source\""             // want "tagged field: another"
+	hasCustomFieldTag        string      `example:"sensitive"`          // want "tagged field: hasCustomFieldTag"
+	hasTagWithMultipleValues string      `example:"val,sensitive,long"` // want "tagged field: hasTagWithMultipleValues"
 	name                     string      `some_key:"non_secret"`
 	spaceAfterFinalQuote     string      `key:"value" `
 	someNotTaggedField       int

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,11 +15,11 @@
 package fieldtags
 
 type Person struct {
-	password, creds          string      `levee:"source"`               // want "tagged field: password, creds"
-	secret                   string      `json:"secret" levee:"source"` // want "tagged field: secret"
-	another                  interface{} "levee:\"source\""             // want "tagged field: another"
-	hasCustomFieldTag        string      `example:"sensitive"`          // want "tagged field: hasCustomFieldTag"
-	hasTagWithMultipleValues string      `example:"sensitive,verbose"`  // want "tagged field: hasTagWithMultipleValues"
+	password, creds          string      `levee:"source"`                   // want "tagged field: password, creds"
+	secret                   string      `json:"secret" levee:"source"`     // want "tagged field: secret"
+	another                  interface{} "levee:\"source\""                 // want "tagged field: another"
+	hasCustomFieldTag        string      `example:"sensitive"`              // want "tagged field: hasCustomFieldTag"
+	hasTagWithMultipleValues string      `example:"sensitive,verbose,long"` // want "tagged field: hasTagWithMultipleValues"
 	name                     string      `some_key:"non_secret"`
 	spaceAfterFinalQuote     string      `key:"value" `
 	someNotTaggedField       int

--- a/internal/pkg/fieldtags/testdata/src/tests/test.go
+++ b/internal/pkg/fieldtags/testdata/src/tests/test.go
@@ -15,12 +15,11 @@
 package fieldtags
 
 type Person struct {
-	password, creds          string      `levee:"source"`               // want "tagged field: password, creds"
-	secret                   string      `json:"secret" levee:"source"` // want "tagged field: secret"
-	another                  interface{} "levee:\"source\""             // want "tagged field: another"
-	hasCustomFieldTag        string      `example:"sensitive"`          // want "tagged field: hasCustomFieldTag"
-	hasTagWithMultipleValues string      `levee:"value0,source,value2"` // want "tagged field: hasTagWithMultipleValues"
-	name                     string      `some_key:"non_secret"`
-	spaceAfterFinalQuote     string      `key:"value" `
+	password, creds          string `levee:"source"`               // want "tagged field: password, creds"
+	secret                   string `json:"secret" levee:"source"` // want "tagged field: secret"
+	hasCustomFieldTag        string `example:"sensitive"`          // want "tagged field: hasCustomFieldTag"
+	hasTagWithMultipleValues string `example:"sensitive,verbose"`  // want "tagged field: hasTagWithMultipleValues"
+	name                     string `some_key:"non_secret"`
+	spaceAfterFinalQuote     string `key:"value" `
 	someNotTaggedField       int
 }


### PR DESCRIPTION
It looks like `StructTag` is just a named `string` and we can co-opt `StructTag.Get`.

While `go vet -structtag` doesn't complain about it, it does interact strangely with escaped tags like `"levee:\"source\""`.  But it is much cleaner to use it as the community standard truth.

Opening this PR as a draft until conflicting PRs are merged.