### PR TITLE
Add tests for embedded structs + fields

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/embedding/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/embedding/tests.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embedding
+
+import (
+	"example.com/core"
+)
+
+type EmbedsSource struct {
+	core.Source
+}
+
+type EmbedsSourcePointer struct {
+	*core.Source
+}
+
+func TestStructThatEmbedsSourceIsSource() {
+	core.Sink(EmbedsSource{}) // TODO want "a source has reached a sink"
+}
+
+func TestStructThatEmbedsSourcePointerIsSource() {
+	core.Sink(EmbedsSourcePointer{}) // TODO want "a source has reached a sink"
+}
+
+func TestEmbeddedSourceFieldIsSourceField() {
+	core.Sink(EmbedsSource{}.Data) // want "a source has reached a sink"
+}
+
+func TestEmbeddedSourcePointerFieldIsSourceField() {
+	core.Sink(EmbedsSourcePointer{}.Data) // want "a source has reached a sink"
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/embedding/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/embedding/tests.go
@@ -34,6 +34,14 @@ func TestStructThatEmbedsSourcePointerIsSource() {
 	core.Sink(EmbedsSourcePointer{}) // TODO want "a source has reached a sink"
 }
 
+func TestEmbeddedSourceIsSource() {
+	core.Sink(EmbedsSource{}.Source) // want "a source has reached a sink"
+}
+
+func TestEmbeddedSourcePointerIsSource() {
+	core.Sink(EmbedsSource{}.Source) // want "a source has reached a sink"
+}
+
 func TestEmbeddedSourceFieldIsSourceField() {
 	core.Sink(EmbedsSource{}.Data) // want "a source has reached a sink"
 }

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -381,7 +381,7 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 				}
 
 			// source obtained through a field or an index operation
-			case *ssa.FieldAddr, *ssa.IndexAddr, *ssa.Lookup:
+			case *ssa.Field, *ssa.FieldAddr, *ssa.IndexAddr, *ssa.Lookup:
 			}
 
 			// all of the instructions that the switch lets through are values as per ssa/doc.go


### PR DESCRIPTION
This PR adds tests for embedded structs and fields.

Structs that embed Source structs are not currently considered Sources themselves. This is why 2 of the tests have `TODO`s. This is in relation to issue #97.

The other tests are made to pass by a small change to `source.go`.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR