### PR TITLE
Do not visit any Extract's operands

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -37,7 +37,7 @@ func TestOnlySourceExtractIsTaintedFromCall() {
 }
 
 func TestOnlySourceExtractIsTaintedFromLookup() {
-	s, ok := map[string]*core.Source{}[""]
+	s, ok := map[string]core.Source{}[""]
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(ok)
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -30,10 +30,16 @@ func TakeSource(s core.Source) (string, int, interface{}) {
 	return "", 0, nil
 }
 
-func TestOnlySourceExtractIsTainted() {
+func TestOnlySourceExtractIsTaintedFromCall() {
 	s, err := CreateSource()
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(err)
+}
+
+func TestOnlySourceExtractIsTaintedFromLookup() {
+	s, ok := map[string]*core.Source{}[""]
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(ok)
 }
 
 func TestOnlySourceExtractIsTaintedInstructionOrder() {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -217,7 +217,7 @@ func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReache
 	// produces, e.g. a call to a function with a signature like:
 	// func NewSource() (*core.Source, error)
 	// Which leads to a flow like:
-	// Extract (core.Source) --> Call (NewSource) --> error
+	// Extract (*core.Source) --> Call (NewSource) --> error
 	if _, ok := n.(*ssa.Extract); ok {
 		return
 	}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -211,20 +211,20 @@ func (s *Source) canReach(start *ssa.BasicBlock, dest *ssa.BasicBlock) bool {
 }
 
 func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
-	_, visitingFromExtract := n.(*ssa.Extract)
+	// Do not visit Operands if the current node is an Extract.
+	// This is to avoid incorrectly tainting non-Source values that are
+	// produced by an Instruction that has a Source among the values it
+	// produces, e.g. a call to a function with a signature like:
+	// func NewSource() (*core.Source, error)
+	// Which leads to a flow like:
+	// Extract (core.Source) --> Call (NewSource) --> error
+	if _, ok := n.(*ssa.Extract); ok {
+		return
+	}
 
 	for _, o := range operands {
 		n, ok := (*o).(ssa.Node)
 		if !ok {
-			continue
-		}
-
-		// Do not visit a Call if the current node is an Extract.
-		// This is to avoid incorrectly tainting non-Source values that are
-		// returned from a call that has a Source among its return values,
-		// e.g. a call to a function with a signature like:
-		// func CreateSource() (core.Source, error)
-		if _, ok := (*o).(*ssa.Call); visitingFromExtract && ok {
 			continue
 		}
 


### PR DESCRIPTION
An `Extract`'s `Operands` contain the `Instruction` (`Value`) that produced it. We should never traverse to it, not just for `Calls` (e.g. we should also avoid traversing to `Lookups`).

- [x] Tests pass
- [x] Appropriate changes to README are included in PR