### PR TITLE
Example config: use log instead of k?log$

### DIFF
--- a/configuration/example-config.json
+++ b/configuration/example-config.json
@@ -23,7 +23,7 @@
   ],
   "Sinks": [
     {
-      "PackageRE": "k?log$",
+      "PackageRE": "log",
       "ReceiverRE": "",
       "MethodRE": "Info|Warning|Error|Fatal|Exit"
     }


### PR DESCRIPTION
The current config is slightly outdated. I think we should use just plain "log", as the substring "log" should occur in all logging packages (we may care about more than `klog`) and is unlikely to occur outside of logging packages.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR