### PR TITLE
Consider source collections to be sources

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/sources.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/sources.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collections
+
+import (
+	"example.com/core"
+)
+
+func TestSourceMapIsSource() {
+	core.Sink(map[string]string{})
+	core.Sink(map[core.Source]string{})      // want "a source has reached a sink"
+	core.Sink(map[string]core.Source{})      // want "a source has reached a sink"
+	core.Sink(map[core.Source]core.Source{}) // want "a source has reached a sink"
+}
+
+func TestSourceArrayIsSource() {
+	core.Sink([1]string{})
+	core.Sink([1]core.Source{}) // want "a source has reached a sink"
+}
+
+func TestSourceSliceIsSource() {
+	core.Sink([]string{})
+	core.Sink([]core.Source{}) // want "a source has reached a sink"
+}
+
+func TestSourceChanIsSource() {
+	core.Sink(make(chan string))
+	core.Sink(make(chan core.Source)) // want "a source has reached a sink"
+}
+
+func TestSourcePointerCollectionIsSource() {
+	core.Sink([]*core.Source{}) // want "a source has reached a sink"
+}
+
+func TestSourceCollectionParamIsSource(ss []core.Source) {
+	core.Sink(ss) // want "a source has reached a sink"
+}
+
+func TestSourceCollectionReturnedFromFunctionCallIsSource() {
+	core.Sink(GetSourcesSlice()) // want "a source has reached a sink"
+	core.Sink(GetSourcesMap())   // want "a source has reached a sink"
+}
+
+func TestSourceCollectionReturnedFromMethodCallIsSource() {
+	core.Sink(SourcesHolder{}.GetSourcesSlice()) // want "a source has reached a sink"
+	core.Sink(SourcesHolder{}.GetSourcesMap())   // want "a source has reached a sink"
+}
+
+func TestSourceCollectionInStructFieldIsSource() {
+	core.Sink(SourcesHolder{}.Sources)    // want "a source has reached a sink"
+	core.Sink(SourcesHolder{}.SourcesMap) // want "a source has reached a sink"
+}
+
+type SourceSlice []core.Source
+
+func TestAliasedSourceSollectionIsSource() {
+	core.Sink(SourceSlice{}) // want "a source has reached a sink"
+}
+
+type DeeplyNested map[string][]map[string]map[string][][]map[string]core.Source
+
+func TestDeeplyNestedSourceCollectionIsSource() {
+	core.Sink(DeeplyNested{}) // want "a source has reached a sink"
+}
+
+func GetSourcesSlice() []core.Source {
+	return nil
+}
+
+func GetSourcesMap() map[string]core.Source {
+	return nil
+}
+
+type SourcesHolder struct {
+	Sources    []core.Source
+	SourcesMap map[string]core.Source
+}
+
+func (sh SourcesHolder) GetSourcesSlice() []core.Source {
+	return sh.Sources
+}
+
+func (sh SourcesHolder) GetSourcesMap() map[string]core.Source {
+	return sh.SourcesMap
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/pointers/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/pointers/tests.go
@@ -24,9 +24,9 @@ func TestNew() {
 }
 
 func TestDoublePointer(s **core.Source) {
-	core.Sink(s)   // TODO want "a source has reached a sink"
-	core.Sink(*s)  // TODO want "a source has reached a sink"
-	core.Sink(**s) // TODO want "a source has reached a sink"
+	core.Sink(s)   // want "a source has reached a sink"
+	core.Sink(*s)  // want "a source has reached a sink"
+	core.Sink(**s) // want "a source has reached a sink"
 }
 
 func TestDoubleReference(s core.Source) {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -380,7 +380,7 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 			// source obtained through a field or an index operation
 			case *ssa.Field, *ssa.FieldAddr, *ssa.IndexAddr, *ssa.Lookup:
 
-			// source map (arrays and slices have regular Allocs)
+			// source chan or map (arrays and slices have regular Allocs)
 			case *ssa.MakeMap, *ssa.MakeChan:
 			}
 

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -314,11 +314,8 @@ func identify(conf classifier, ssaInput *buildssa.SSA) map[*ssa.Function][]*Sour
 func sourcesFromParams(fn *ssa.Function, conf classifier) []*Source {
 	var sources []*Source
 	for _, p := range fn.Params {
-		switch t := p.Type().(type) {
-		case *types.Pointer:
-			if n, ok := t.Elem().(*types.Named); ok && conf.IsSource(n) {
-				sources = append(sources, New(p, conf))
-			}
+		if isSourceType(conf, p.Type()) {
+			sources = append(sources, New(p, conf))
 		}
 	}
 	return sources
@@ -382,15 +379,37 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 
 			// source obtained through a field or an index operation
 			case *ssa.Field, *ssa.FieldAddr, *ssa.IndexAddr, *ssa.Lookup:
+
+			// source map (arrays and slices have regular Allocs)
+			case *ssa.MakeMap, *ssa.MakeChan:
 			}
 
 			// all of the instructions that the switch lets through are values as per ssa/doc.go
-			if v := instr.(ssa.Value); conf.IsSource(utils.Dereference(v.Type())) {
+			if v := instr.(ssa.Value); isSourceType(conf, v.Type()) {
 				sources = append(sources, New(v.(ssa.Node), conf))
 			}
 		}
 	}
 	return sources
+}
+
+func isSourceType(c classifier, t types.Type) bool {
+	deref := utils.Dereference(t)
+	switch tt := deref.(type) {
+	case *types.Array:
+		return isSourceType(c, tt.Elem())
+	case *types.Slice:
+		return isSourceType(c, tt.Elem())
+	case *types.Chan:
+		return isSourceType(c, tt.Elem())
+	case *types.Map:
+		key := isSourceType(c, tt.Key())
+		elem := isSourceType(c, tt.Elem())
+		return key || elem
+	default:
+		u := tt.Underlying()
+		return c.IsSource(tt) || (u != tt && isSourceType(c, u))
+	}
 }
 
 func isProducedBySanitizer(v ssa.Value, conf classifier) bool {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -406,9 +406,10 @@ func isSourceType(c classifier, t types.Type) bool {
 		key := isSourceType(c, tt.Key())
 		elem := isSourceType(c, tt.Elem())
 		return key || elem
+	case *types.Basic, *types.Interface, *types.Tuple, *types.Struct:
+		return false
 	default:
-		u := tt.Underlying()
-		return c.IsSource(tt) || (u != tt && isSourceType(c, u))
+		return c.IsSource(tt) || isSourceType(c, tt.Underlying())
 	}
 }
 

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
@@ -46,17 +46,37 @@ func TestSourceDeclarations() {
 	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulataed, alias, def)
 }
 
-// A report should be emitted for each parameter.
-func TestSourceParameters(val Source, ptr *Source) { // want "source identified" "source identified"
+// A report should be emitted for each parameter, as well as the (implicit) Alloc for val.
+func TestSourceParameters(val Source, ptr *Source) { // want "source identified" "source identified" "source identified"
 
 }
 
 func TestSourceExtracts() {
-	s, err := CreateSource()                     // want "source identified"
-	sptr, err := NewSource()                     // want "source identified"
-	mapSource, ok := map[string]Source{}[""]     // want "source identified"
-	mapSourcePtr, ok := map[string]*Source{}[""] // want "source identified"
-	chanSource, ok := <-(make(chan Source))      // want "source identified"
-	chanSourcePtr, ok := <-(make(chan *Source))  // want "source identified"
+	s, err := CreateSource() // want "source identified"
+	sptr, err := NewSource() // want "source identified"
+
+	// we expect two reports for the following cases, since the map is a Source
+	mapSource, ok := map[string]Source{}[""]     // want "source identified" "source identified"
+	mapSourcePtr, ok := map[string]*Source{}[""] // want "source identified" "source identified"
+
+	// we expect two reports for the following cases, since the chan is a Source
+	chanSource, ok := <-(make(chan Source))     // want "source identified" "source identified"
+	chanSourcePtr, ok := <-(make(chan *Source)) // want "source identified" "source identified"
+
 	_, _, _, _, _, _, _, _ = s, sptr, mapSource, chanSource, mapSourcePtr, chanSourcePtr, err, ok
 }
+
+func TestCollections(ss []Source) { // want "source identified"
+	_ = map[Source]string{} // want "source identified"
+	_ = map[string]Source{} // want "source identified"
+	_ = map[Source]Source{} // want "source identified"
+	_ = [1]Source{}         // want "source identified"
+	_ = []Source{}          // want "source identified"
+	_ = make(chan Source)   // want "source identified"
+	_ = []*Source{}         // want "source identified"
+	_ = SourceSlice{}       // want "source identified"
+	_ = DeeplyNested{}      // want "source identified"
+}
+
+type SourceSlice []Source
+type DeeplyNested map[string][]map[string]map[string][][]map[string]Source


### PR DESCRIPTION
## Context

This PR is inspired by a case I stumbled upon recently that the analyzer currently isn't catching:

```go
func Oops() {
  ss := GetSources()
  core.Sink(ss) // TODO: want "a source has reached a sink" 
}

func GetSources() []Source {
  return nil // omitted for simplicity
}
```

Since we don't know what the `GetSources` call is doing, we should assume that it is returning a slice containing at least 1 unsanitized `Source`. This may not be the case: the slice may be empty, or it may contain only unsanitized sources. However, without interprocedural analysis (#99) and granular taint tracking for collections (#47), and likely other features, in general we should assume that collections that hold Sources are themselves Sources, such that 

## The PR

This PR adds support for identification of Source-holding collections as Sources. This entails:
* Adding tests for the `levee` and `source` analyzers. (As a "side-effect", we get a few currently failing tests to pass, as well.)
* Changes to `source.go`. Most of these, especially the `isSourceType` function, should be in the `sourcetype` analyzer, but it is not yet consumed anywhere, so currently I think this is the best place to make those changes. (Incidentally, I think having this functionality makes a good case for updating and consuming the `sourcetype` analyzer, so I am planning on doing that next.)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR