### PR TITLE
Revert "Do not visit any Extract's operands (#134)"

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -30,16 +30,10 @@ func TakeSource(s core.Source) (string, int, interface{}) {
 	return "", 0, nil
 }
 
-func TestOnlySourceExtractIsTaintedFromCall() {
+func TestOnlySourceExtractIsTainted() {
 	s, err := CreateSource()
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(err)
-}
-
-func TestOnlySourceExtractIsTaintedFromLookup() {
-	s, ok := map[string]core.Source{}[""]
-	core.Sink(s) // want "a source has reached a sink"
-	core.Sink(ok)
 }
 
 func TestOnlySourceExtractIsTaintedInstructionOrder() {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -218,20 +218,20 @@ func (s *Source) canReach(start *ssa.BasicBlock, dest *ssa.BasicBlock) bool {
 }
 
 func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
-	// Do not visit Operands if the current node is an Extract.
-	// This is to avoid incorrectly tainting non-Source values that are
-	// produced by an Instruction that has a Source among the values it
-	// produces, e.g. a call to a function with a signature like:
-	// func NewSource() (*core.Source, error)
-	// Which leads to a flow like:
-	// Extract (*core.Source) --> Call (NewSource) --> error
-	if _, ok := n.(*ssa.Extract); ok {
-		return
-	}
+	_, visitingFromExtract := n.(*ssa.Extract)
 
 	for _, o := range operands {
 		n, ok := (*o).(ssa.Node)
 		if !ok {
+			continue
+		}
+
+		// Do not visit a Call if the current node is an Extract.
+		// This is to avoid incorrectly tainting non-Source values that are
+		// returned from a call that has a Source among its return values,
+		// e.g. a call to a function with a signature like:
+		// func CreateSource() (core.Source, error)
+		if _, ok := (*o).(*ssa.Call); visitingFromExtract && ok {
 			continue
 		}
 


### PR DESCRIPTION
This reverts commit 93f91d45eb51dd7b2b9c0f0c2a36d02090118f9b.

Fixes current test failures on `master`
