### PR TITLE
Do not traverse from extracts to operands

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -30,10 +30,16 @@ func TakeSource(s core.Source) (string, int, interface{}) {
 	return "", 0, nil
 }
 
-func TestOnlySourceExtractIsTainted() {
+func TestOnlySourceExtractIsTaintedFromCall() {
 	s, err := CreateSource()
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(err)
+}
+
+func TestOnlySourceExtractIsTaintedFromLookup() {
+	s, ok := map[string]core.Source{}[""]
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(ok)
 }
 
 func TestOnlySourceExtractIsTaintedInstructionOrder() {


### PR DESCRIPTION
See #142 for context.

This PR re-introduces the behavior of "not traversing to an Extract's Operands". Traversing to an Extract's operands never makes sense because it means we are propagating taint "backwards in time". Indeed, the Extract instruction always comes after the instruction that produced the Tuple that the Extract is extracting a value from.

This PR also prevents traversing to the boolean in a comma-ok Lookup, e.g.:
```
source, ok := map[string]Source{"key": Source{"password"}}["key"]
```
In such a situation, we do not want to taint the boolean, since there is no way that it could contain sensitive information. However, it might propagate taint to a sink, which would cause an incorrect report. There is a test case to verify that this does not occur. 

Given that the changes in this PR are derived from recent PR's that we have discussed, and that they touch the same area in terms of testing, I feel like it is ok to bundle up the changes in 1 PR. If you feel differently, please let me know and I will split the changes up.

## More details concerning the tests

```go
func TestOnlySourceExtractIsTaintedFromLookup() {
	s, ok := map[string]core.Source{}[""]
	core.Sink(s) // want "a source has reached a sink"
	core.Sink(ok)
}
```
This test cases only requires the changes to how `Lookups` are handled, since both paths (from the `core.Source` `Extract` as well as from the `MakeMap`, which is also a source) have to go through the `Lookup`.

```go
func TestOnlySourceExtractIsTaintedFromRecv() {
	s, ok := <-make(chan core.Source)
	core.Sink(s) // want "a source has reached a sink"
	core.Sink(ok)
}
```
This test case demonstrates that not propagating from `Extracts` to their `Operands` works in the `<-chan` case, not just when the `Extract` is tied to a `Call`.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR