### PR TITLE
Do not traverse from an Extract to its Operands

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -30,10 +30,16 @@ func TakeSource(s core.Source) (string, int, interface{}) {
 	return "", 0, nil
 }
 
-func TestOnlySourceExtractIsTainted() {
+func TestOnlySourceExtractIsTaintedFromCall() {
 	s, err := CreateSource()
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(err)
+}
+
+func TestOnlySourceExtractIsTaintedFromTypeAssert(p interface{}) {
+	s, ok := p.(core.Source)
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(ok)
 }
 
 func TestOnlySourceExtractIsTaintedInstructionOrder() {


### PR DESCRIPTION
See #142 for context.

This PR re-introduces the behavior of "not traversing to an Extract's Operands". Traversing to an Extract's operands never makes sense because it means we are propagating taint "backwards in time". Indeed, the Extract instruction always comes after the instruction that produced the Tuple that the Extract is extracting a value from. Up to now, we were only avoiding this traversal when the `Operand` is a `Call`.

As extra justification for this change, this PR adds a test that would otherwise fail (involving a `TypeAssert` instead of a `Call`).

Tests + changes for the case that caused the failure on master are here: #146.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR