### PR TITLE
Do not traverse to booleans

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/booleans/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/booleans/tests.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inlining
+
+import (
+	"example.com/core"
+)
+
+func HasSecret(s core.Source) bool {
+	return s.Data != ""
+}
+
+func TestDoNotTraverseToBoolean(s core.Source) {
+	ok := HasSecret(s)
+	core.Sink(ok)
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -22,6 +22,10 @@ func CreateSource() (core.Source, error) {
 	return core.Source{}, nil
 }
 
+func TryUpdateSource(s core.Source) (core.Source, bool) {
+	return s, true
+}
+
 func CreateSourceFlipped() (error, core.Source) {
 	return nil, core.Source{}
 }
@@ -31,12 +35,13 @@ func TakeSource(s core.Source) (string, int, interface{}) {
 }
 
 func TestOnlySourceExtractIsTaintedFromCall() {
-	s, err := CreateSource()
+	s, ok := TryUpdateSource(core.Source{})
 	core.Sink(s) // want "a source has reached a sink"
-	core.Sink(err)
+	core.Sink(ok)
 }
 
-func TestOnlySourceExtractIsTaintedFromTypeAssert(p interface{}) {
+func TestOnlySourceExtractIsTaintedFromTypeAssert(s core.Source) {
+	var p interface{} = s
 	s, ok := p.(core.Source)
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(ok)

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -30,10 +30,16 @@ func TakeSource(s core.Source) (string, int, interface{}) {
 	return "", 0, nil
 }
 
-func TestOnlySourceExtractIsTainted() {
+func TestOnlySourceExtractIsTaintedFromCall() {
 	s, err := CreateSource()
 	core.Sink(s) // want "a source has reached a sink"
 	core.Sink(err)
+}
+
+func TestOnlySourceExtractIsTaintedFromTypeAssert(p interface{}) {
+	s, ok := p.(core.Source)
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(ok)
 }
 
 func TestOnlySourceExtractIsTaintedInstructionOrder() {

--- a/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/extracts/tests.go
@@ -42,6 +42,18 @@ func TestOnlySourceExtractIsTaintedFromTypeAssert(p interface{}) {
 	core.Sink(ok)
 }
 
+func TestOnlySourceExtractIsTaintedFromLookup() {
+	s, ok := map[string]core.Source{}[""]
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(ok)
+}
+
+func TestOnlySourceExtractIsTaintedFromChanRecv() {
+	s, ok := <-make(chan core.Source)
+	core.Sink(s) // want "a source has reached a sink"
+	core.Sink(ok)
+}
+
 func TestOnlySourceExtractIsTaintedInstructionOrder() {
 	s, err := CreateSource()
 	core.Sink(err)

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -87,10 +87,8 @@ func (s *Source) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBl
 		return
 	}
 	// booleans can't meaningfully be tainted
-	if v, ok := n.(ssa.Value); ok {
-		if basic, ok := v.Type().(*types.Basic); ok && basic.Info() == types.IsBoolean {
-			return
-		}
+	if isBoolean(n) {
+		return
 	}
 
 	mirCopy := map[*ssa.BasicBlock]int{}
@@ -405,6 +403,15 @@ func sourcesFromBlocks(fn *ssa.Function, conf classifier) []*Source {
 		}
 	}
 	return sources
+}
+
+func isBoolean(n ssa.Node) bool {
+	if v, ok := n.(ssa.Value); ok {
+		if basic, ok := v.Type().(*types.Basic); ok && basic.Info() == types.IsBoolean {
+			return true
+		}
+	}
+	return false
 }
 
 func isSourceType(c classifier, t types.Type) bool {


### PR DESCRIPTION
This PR builds on #145.

I am opening this PR to fix a bug that we currently have: when there is a comma-ok form, e.g. `s, ok := map[string]Source{}[""]`, we are currently propagating from the `Lookup` instruction to the `boolean` `Extract` (the `ok` value), which does not make sense: the boolean isn't tainted. This also occurs with `chan` receives, which appear as `UnOp` instruction. To my knowledge, no other `UnOps` can use the comma-ok form.

Since booleans can't meaningfully be tainted, this PR modifies the traversal to avoid booleans altogether.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR