### PR TITLE
Add tests for type assertions and type switches

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/switch/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/switch/tests.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _switch
+
+import (
+	"example.com/core"
+)
+
+func TestTypeSwitch(i interface{}) {
+	switch t := i.(type) {
+	case core.Innocuous:
+		core.Sink(i)
+		core.Sink(t)
+	case *core.Source:
+		core.Sink(i) // TODO/discuss - do we want "a source has reached a sink"
+		core.Sink(t) // want "a source has reached a sink"
+	case core.Source:
+		core.Sink(i) // TODO/discuss - do we want "a source has reached a sink"
+		core.Sink(t) // want "a source has reached a sink"
+	default:
+		core.Sink(i)
+		core.Sink(t)
+	}
+}
+
+func TestTypeSwitchInline(i interface{}) {
+	switch i.(type) {
+	case core.Innocuous, *core.Source, core.Source:
+		core.Sink(i) // TODO/discuss - do we want "a source has reached a sink"
+	default:
+		// do nothing
+	}
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package _switch
+package typeassert
 
 import (
 	"example.com/core"
@@ -24,10 +24,12 @@ func TestTypeSwitch(i interface{}) {
 		core.Sink(i)
 		core.Sink(t)
 	case *core.Source:
-		core.Sink(i) // TODO/discuss - do we want "a source has reached a sink"
+		// The type of i is definitively known within this block
+		core.Sink(i) // TODO want "a source has reached a sink"
 		core.Sink(t) // want "a source has reached a sink"
 	case core.Source:
-		core.Sink(i) // TODO/discuss - do we want "a source has reached a sink"
+		// The type of i is definitively known within this block
+		core.Sink(i) // TODO want "a source has reached a sink"
 		core.Sink(t) // want "a source has reached a sink"
 	default:
 		core.Sink(i)
@@ -38,8 +40,23 @@ func TestTypeSwitch(i interface{}) {
 func TestTypeSwitchInline(i interface{}) {
 	switch i.(type) {
 	case core.Innocuous, *core.Source, core.Source:
-		core.Sink(i) // TODO/discuss - do we want "a source has reached a sink"
+		// While not definitively known, the type of i may be asserted to be a source type
+		core.Sink(i) // TODO want "a source has reached a sink"
 	default:
 		// do nothing
 	}
+}
+
+func TestPanicTypeAssert(i interface{}) {
+	s := t.(core.Source)
+	_ = s
+	// The dominating type assertion would panic if i were not a source type.
+	core.Sink(i) // TODO want "a source has reached a sink"
+}
+
+func TestOkayTypeAssert(i interface{}) {
+	s, ok := t.(core.Source)
+	_, _ = s, ok
+	// The dominating type assertion will not panic.  Value of ok is not known, so we cannot presume the type of i
+	core.Sink(i)
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
@@ -47,16 +47,26 @@ func TestTypeSwitchInline(i interface{}) {
 	}
 }
 
-func TestPanicTypeAssert(i interface{}) {
-	s := t.(core.Source)
+func TestPanicTypeAssertSource(i interface{}) {
+	s := i.(core.Source)
 	_ = s
 	// The dominating type assertion would panic if i were not a source type.
-	core.Sink(i) // TODO want "a source has reached a sink"
+	core.Sink(i) // want "a source has reached a sink"
+}
+
+func TestPanicTypeAssertInnocuous(i interface{}) {
+	// TypeAssert instructions should not cause reports by themselves.
+	innoc := i.(core.Innocuous)
+	_ = innoc
+	core.Sink(i)
 }
 
 func TestOkayTypeAssert(i interface{}) {
-	s, ok := t.(core.Source)
+	s, ok := i.(core.Source)
 	_, _ = s, ok
-	// The dominating type assertion will not panic.  Value of ok is not known, so we cannot presume the type of i
-	core.Sink(i)
+	// The dominating type assertion will not panic.
+	// TODO: Should this produce a report?
+	// Currently, the source s appears to "backflow" into i, causing report.
+	core.Sink(i) // want "a source has reached a sink"
+
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
@@ -65,8 +65,5 @@ func TestOkayTypeAssert(i interface{}) {
 	s, ok := i.(core.Source)
 	_, _ = s, ok
 	// The dominating type assertion will not panic.
-	// TODO: Should this produce a report?
-	// Currently, the source s appears to "backflow" into i, causing report.
-	core.Sink(i) // want "a source has reached a sink"
-
+	core.Sink(i)
 }


### PR DESCRIPTION
It crossed my mind that we don't have test coverage for type switches.  We appear to catch any source when it's reassigned to an identifyable type, but don't identify an source obfuscated by interface, even when we're in a block that would require that type.

That make sense given our current implementation and limitations.  This might be trivialized by our general conversations surrounding how we plan to puncture the `interface` obfuscation problem.  If not, we might need a way to mark an item as a source only within the scope of specific `Block`s.

We have a good priority set right now.  I just wanted to get a thread stated while it was top of mind.

