### PR TITLE
Defend against infinite recursion in source identification.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@ Fixes #<issue_number_goes_here>
 > It's a good idea to open an issue first for discussion.
 
 - [ ] Tests pass
-- [ ] Running against a large codebase such as kubernetes/kubernetes does not error out.
+- [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
 - [ ] Appropriate changes to README are included in PR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,5 @@ Fixes #<issue_number_goes_here>
 > It's a good idea to open an issue first for discussion.
 
 - [ ] Tests pass
+- [ ] Running against a large codebase such as kubernetes/kubernetes does not error out.
 - [ ] Appropriate changes to README are included in PR

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -415,15 +415,16 @@ func isSourceType(c classifier, t types.Type) bool {
 		key := isSourceType(c, tt.Key())
 		elem := isSourceType(c, tt.Elem())
 		return key || elem
-	case *types.Basic, *types.Struct, *types.Tuple, *types.Interface, *types.Signature, *types.Pointer:
+	case *types.Basic, *types.Struct, *types.Tuple, *types.Interface, *types.Signature:
+		// These types do not currently represent possible source types
+		return false
+	case *types.Pointer:
+		// This should be unreachable due to the dereference above
 		return false
 	default:
-		// The above case is a safeguard against infinite recursion.
-		// If we missed a case, we should panic.
-		if tt.Underlying() == tt {
-			panic(fmt.Errorf("heading into infinite loop on isSourceType, <%T> %v", tt, tt))
-		}
-		return isSourceType(c, tt.Underlying())
+		// The above should be exhaustive.  Reaching this default case is an error.
+		fmt.Printf("unexpected type received: %T %v; please report this issue\n", tt, tt)
+		return false
 	}
 }
 

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
@@ -26,6 +26,7 @@ type FuncField struct {
 	ptr      func() *Source
 }
 
+// This test exercises isSourceType for *types.Signature and related interactions.
 func TestFunctionFields() {
 	bar := FuncField{
 		flipCoin: func() bool {

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
@@ -20,6 +20,34 @@ type Alias = Source
 // type definition where the underlying type is a Source
 type Definition Source
 
+type FuncField struct {
+	flipCoin func() bool
+	producer func() Source
+	ptr      func() *Source
+}
+
+func TestFunctionFields() {
+	bar := FuncField{
+		flipCoin: func() bool {
+			return true // It's a trick coin
+		},
+		producer: func() Source {
+			return Source{} // want "source identified"
+		},
+		ptr: func() *Source {
+			return &Source{} // want "source identified"
+		},
+	}
+
+	// When the assigned-to type is a Source, then we expect two Allocs, and therefore two Source identifications.
+	// This Alloc doesn't occur if the assigned-to type is a pointer or interface
+	var i interface{} = bar.producer() // want "source identified"
+	s := bar.producer()                // want "source identified" "source identified"
+	ptr := bar.ptr()                   // want "source identified"
+
+	noop(bar, s, i, ptr)
+}
+
 // This function allows us to consume multiple arguments in a single line so this file can compile
 func noop(args ...interface{}) {}
 


### PR DESCRIPTION
I was running `master` against Kubernetes and blew the stack.  `*types.Signature` is also self-referential with `tt.Underlying()`.  It looks like `*types.Pointer` is, too.

I need to run that failure mode again to get a real test-case for it, but figure I'd open it quickly for review of the main changes.  Of course, trying something like `type Producer func() Source` ends up getting handled as a `*types.Named` rather than a `*types.Signature`, so we're hitting that corner of "`analysistest` is kind of hard to work with."

* Promote examination of `*types.Named` as the "main" identification case.
    *  If we're sticking to that pattern, we should consider renaming `IsSource` to something like `IsNamedSource` or something, to counter `IsSourceType`.  I'll leave that to a future PR discussion though.
* Enumerate all the kinds that we are ignoring, and add a panic if we're missing something.
    * I know we generally shouldn't panic, but I consider this an indication of catastrophic failure in need of immediate remediation.
    * If you hate it, I could be talked into rewriting this to cover all `types` Kinds, and having the `default:` case print an error and returning false to indicate a gap in our structure here.
