### PR TITLE
Add tests for named return values

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
@@ -24,7 +24,7 @@ func TestNamedReturnValue() (s core.Source) {
 }
 
 func TestNamedReturnValuePointer() (s *core.Source) {
-	core.Sink(s) // we do not want a report here, because no Source value has been created
+	core.Sink(s) // we do not report here, because no Source value has been created, so s must be nil
 	return
 }
 

--- a/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
@@ -27,3 +27,9 @@ func TestNamedReturnValuePointer() (s *core.Source) {
 	core.Sink(s) // we do not want a report here, because no Source value has been created
 	return
 }
+
+func TestNamedReturnValuePointerWithInitialization() (s *core.Source) {
+	s = &core.Source{}
+	core.Sink(s) // want "a source has reached a sink"
+	return
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namedreturn
+
+import (
+	"example.com/core"
+)
+
+func TestNamedReturnValue() (s core.Source) {
+	core.Sink(s) // want "a source has reached a sink"
+	return
+}
+
+func TestNamedReturnValuePointer() (s *core.Source) {
+	core.Sink(s) // we do not want a report here, because no Source value is being created
+	return
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/namedreturn/tests.go
@@ -24,6 +24,6 @@ func TestNamedReturnValue() (s core.Source) {
 }
 
 func TestNamedReturnValuePointer() (s *core.Source) {
-	core.Sink(s) // we do not want a report here, because no Source value is being created
+	core.Sink(s) // we do not want a report here, because no Source value has been created
 	return
 }

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
@@ -80,6 +80,13 @@ func TestSourceParameters(val Source, ptr *Source) { // want "source identified"
 
 }
 
+// A report should be emitted for val, because it will have an Alloc in the body.
+// A report should *not* be emitted for ptr, because it will not, by itself, lead to
+// the creation of a Source value.
+func TestNamedReturnValues() (val Source, ptr *Source) { // want "source identified"
+	return
+}
+
 func TestSourceExtracts() {
 	s, err := CreateSource() // want "source identified"
 	sptr, err := NewSource() // want "source identified"


### PR DESCRIPTION
This PR adds tests for named return values.

In this case:
```go
func TestNamedReturnValue() (s core.Source) {
	core.Sink(s) // want "a source has reached a sink"
	return
}
```
`s` will get an `Alloc`, as though it had been declared in the body. In the function's `ssa`, `s` is listed as a local variable.

If we change `core.Source` to `*core.Source`, we no longer expect a report. Indeed, the code becomes roughly equivalent to:
```go
func Test() {
	var s *core.Source
	_ = s
}
```
In this case, `s` does not get an `Alloc` (because nothing needs to be allocated), and in fact `s` is not even listed as a local variable (because it is simply nil).

If a value were assigned to the pointer return value, then it would be detected by other means.

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [x] Appropriate changes to README are included in PR