### PR TITLE
Rework configuration to allow YAML and future configuration feature-add.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.2
 	golang.org/x/tools v0.0.0-20200416214402-fc959738d646
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -20,3 +20,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -52,6 +52,24 @@ type fieldTagMatcher struct {
 	Val string
 }
 
+func (f *fieldTagMatcher) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var m map[string]string
+	if err := unmarshal(&m); err != nil {
+		return err
+	}
+
+	if len(m) != 1 {
+		return fmt.Errorf("expected single key-value pair, got %d", len(m))
+	}
+
+	for k, v := range m {
+		f.Key = k
+		f.Val = v
+		break
+	}
+	return nil
+}
+
 // IsSourceFieldTag determines whether a field tag made up of a key and value
 // is a Source.
 func (c Config) IsSourceFieldTag(tag string) bool {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -88,5 +87,4 @@ func TestLoadConfigV2(t *testing.T) {
 	if err != nil {
 		log.Fatalf("cannot unmarshal data: %v", err)
 	}
-	fmt.Printf("%#v\n", cfg)
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -84,7 +84,7 @@ func TestLoadConfigV2(t *testing.T) {
 	}
 
 	var cfg ConfigV2
-	err = yaml.Unmarshal(bytes, &cfg)
+	err = yaml.UnmarshalStrict(bytes, &cfg)
 	if err != nil {
 		log.Fatalf("cannot unmarshal data: %v", err)
 	}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -15,8 +15,13 @@
 package config
 
 import (
+	"fmt"
+	"io/ioutil"
+	"log"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
@@ -69,4 +74,19 @@ func TestConfig(t *testing.T) {
 	for _, p := range []string{"core", "exclusion"} {
 		analysistest.Run(t, testdata, testAnalyzer, filepath.Join(testdata, "src/notexample.com", p))
 	}
+}
+
+func TestLoadConfigV2(t *testing.T) {
+	testdata := analysistest.TestData()
+	bytes, err := ioutil.ReadFile(testdata + "/test-config-v2.yaml")
+	if err != nil {
+		t.Error(err)
+	}
+
+	var cfg ConfigV2
+	err = yaml.Unmarshal(bytes, &cfg)
+	if err != nil {
+		log.Fatalf("cannot unmarshal data: %v", err)
+	}
+	fmt.Printf("%#v\n", cfg)
 }

--- a/internal/pkg/config/regexp/regexp.go
+++ b/internal/pkg/config/regexp/regexp.go
@@ -31,6 +31,16 @@ func (mr *Regexp) MatchString(s string) bool {
 	return mr.r == nil || mr.r.MatchString(s)
 }
 
+func (mr *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+
+	mr.r = regexp.MustCompile(s)
+	return nil
+}
+
 // UnmarshalJSON implementation of json.UnmarshalJSON interface.
 func (mr *Regexp) UnmarshalJSON(data []byte) error {
 	var matcher string

--- a/internal/pkg/config/specifiers.go
+++ b/internal/pkg/config/specifiers.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/google/go-flow-levee/internal/pkg/config/regexp"
+)
+
+// This type marks intended future work
+type NotImplemented = interface{}
+
+type FieldSpec struct {
+	typeSpec `yaml:",inline"`
+	Field    regexp.Regexp
+	Tags     []fieldTagMatcher
+}
+
+func (fs FieldSpec) MatchName(name string) bool {
+	return fs.Field.MatchString(name)
+}
+
+func (fs FieldSpec) MatchTag(key, value string) bool {
+	for _, ftm := range fs.Tags {
+		if ftm.Key == key && ftm.Val == value {
+			return true
+		}
+	}
+	return false
+}
+
+type typeSpec struct {
+	Package regexp.Regexp
+	Type    regexp.Regexp
+}
+
+func (ts typeSpec) Match(pkg, typ string) bool {
+	return ts.Package.MatchString(pkg) && ts.Type.MatchString(typ)
+}
+
+type valueSpec struct {
+	FieldSpec     `yaml:",inline"` // Match according to field name or tags
+	Id            string
+	Unless        []valueSpec
+	Scope         NotImplemented
+	IsReference   NotImplemented
+	MatchConstant NotImplemented
+}
+
+type callSpec struct {
+	typeSpec     // patch package and optional receiver
+	Id           string
+	FunctionName string
+	Arguments    NotImplemented
+}
+
+type metaSpec struct {
+	ValidateConfig NotImplemented `yaml:"validate-config"`
+	Scope          NotImplemented
+}
+
+type Specifier struct {
+	Value *valueSpec `yaml:"value,omitempty"`
+	Call  *callSpec  `yaml:"call,omitempty"`
+}
+
+func (s Specifier) validate() error {
+	switch {
+	case s.Value != nil && s.Call != nil:
+		return fmt.Errorf("a specifier should include only a value or call specification")
+	case s.Value == nil && s.Call == nil:
+		return fmt.Errorf("specifier includes neither a value or call specification")
+	}
+	return nil
+}
+
+// ConfigV2 is a more generic config
+type ConfigV2 struct {
+	Apiversion string
+	Kind       string
+
+	Metadata metaSpec
+
+	Source    []Specifier
+	Sink      []Specifier
+	Sanitizer []Specifier
+	Allowlist []Specifier
+}

--- a/internal/pkg/config/specifiers.go
+++ b/internal/pkg/config/specifiers.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/internal/pkg/config/specifiers.go
+++ b/internal/pkg/config/specifiers.go
@@ -28,10 +28,10 @@ type ConfigV2 struct {
 
 	Metadata metaSpec
 
-	Source    []specifier
-	Sink      []specifier
-	Sanitizer []specifier
-	Allowlist []specifier
+	Sources    []specifier
+	Sinks      []specifier
+	Sanitizers []specifier
+	Allowlist  []specifier
 }
 
 type metaSpec struct {

--- a/internal/pkg/config/specifiers.go
+++ b/internal/pkg/config/specifiers.go
@@ -10,9 +10,9 @@ import (
 type NotImplemented = interface{}
 
 type FieldSpec struct {
-	typeSpec `yaml:",inline"`
-	Field    regexp.Regexp
-	Tags     []fieldTagMatcher
+	typeSpec  `yaml:",inline"`
+	Field     regexp.Regexp
+	Fieldtags []fieldTagMatcher
 }
 
 func (fs FieldSpec) MatchName(name string) bool {
@@ -20,7 +20,7 @@ func (fs FieldSpec) MatchName(name string) bool {
 }
 
 func (fs FieldSpec) MatchTag(key, value string) bool {
-	for _, ftm := range fs.Tags {
+	for _, ftm := range fs.Fieldtags {
 		if ftm.Key == key && ftm.Val == value {
 			return true
 		}

--- a/internal/pkg/config/testdata/src/configv2/discussion/sink_examples.go
+++ b/internal/pkg/config/testdata/src/configv2/discussion/sink_examples.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discussion
+
+import "fmt"
+
+// This sink is identified by name
+func Sink(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+// Calls to Sink here are exempted from identification by the configuration's .unless block.
+// This context has been blessed by a security expert
+func SimpleSinkPermitted(t Token) {
+	Sink(t) // not a sink, so no issue reported
+}
+
+// All SinkType functions are sinks
+type SinkType func(...interface{})
+
+type SinkHolder struct {
+	Sinker func(...interface{}) // Identified as sink by name
+}
+
+type TaggedSinkHolder struct {
+	Sinker func(...interface{}) `myTag:"sink"` // Identified as sink by tag
+}

--- a/internal/pkg/config/testdata/src/configv2/discussion/source_examples.go
+++ b/internal/pkg/config/testdata/src/configv2/discussion/source_examples.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package discussion demonstrates some examples of configuration intended by the new config style
+package discussion
+
+import "os"
+
+// All Tokens are sources, even though the underlying type is a basic kind.
+type Token string
+
+// Since configuration does not specify any field as a source, then any TokenBundle is identified as a source.
+// (Implicitly, every field is a source field.)
+type TokenBundle struct {
+	bundle                     []string
+	masterToken                string
+	internalCommunicationToken string
+}
+
+// Configuration specifically identifies a field as a source in this type.
+// When a type has a source field, direct access of the non-source fields should not propagate taint.
+type NamedToken struct {
+	token string
+	name  string
+}
+
+// Configuration specifically identifies a field as a source in this type via field tag.
+// As above, direct access of non-source fields should not propagate taint.
+type TaggedToken struct {
+	Token string `myTag:"source"`
+	name  string
+}
+
+func Foo() {
+	// The string in this environment variable is sensitive.
+	password := os.Getenv("CFSSL_CA_PK_PASSWORD")
+
+	// The string in this environment variable is not.
+	userDir := os.Getenv("USER_DIR")
+
+	_, _ = password, userDir
+}
+
+func SaveSecret(secret interface{}) {
+	// The parameter secret, though received by interface{}, is still identified as a source.
+}

--- a/internal/pkg/config/testdata/src/configv2/discussion/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/src/configv2/discussion/test-config-v2.yaml
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source:
+  value:
+    - id: "Tokens are secret"
+      package: configv2/discussion
+      type: Token
+    - id: "TokenBundles are entirely secret"
+      package: configv2/discussion
+      type: TokenBundle
+    - id: "NamedToken.token is secret, NamedToken.name is not"
+      package: configv2/discussion
+      type: NamedToken
+      fieldName: token
+    - id: "Tagged fields are secret, neighboring untagged fields are not"
+      # empty package and type fields match anything
+      fieldTag:
+      - myTag: source
+    - id: "In context, the parameter of SaveSecret(secret interface{}) is a source"
+      # this could use additional details and perhaps a better name than "scope"
+      scope: parameter
+      context:
+        package: configv2/discussion
+        functionName: SaveSecret
+  call:
+    - id: "sensitive environment information"
+      package: os
+      function: getEnv
+      arguments:
+      - position: 0
+        const: CFSSL_CA_PK_PASSWORD
+
+sink:
+  call:
+    - id: "Simple Sink"
+      package: configv2/discussion
+      functionName: Sink
+      unless:
+        - context:
+            package: configv2/discussion
+            functionName: SimpleSinkPermitted
+  value:
+    - id: "SinkType marks sinks"
+      package: configv2/discussion
+      type: SinkType
+    - id: "SinkHolder holds a sink"
+      package: configv2/discussion
+      type: SinkHolder
+      fieldName: Sinker
+    - id: "TaggedSinkHolder holds a sink"
+      package: configv2/discussion
+      type: SinkHolder
+      fieldTag:
+        - myTag: sink

--- a/internal/pkg/config/testdata/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/test-config-v2.yaml
@@ -11,14 +11,16 @@ metadata:
 
 source:
 - value:
-    id: "Password field"
+    id: "Core Source"
     package: ^k8s.io/client-go/rest$
     type: ^TLSClientConfig$
     field: Password
 - value:
     # `levee:”source”` should be default, but additional tags
     # should be configurable
-    fieldTag: myTag:"source"
+    fieldtags:
+      - myTag: source
+      - myTag: otherSource
 - call:
     id: "sensitive environment information"
     package: os

--- a/internal/pkg/config/testdata/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/test-config-v2.yaml
@@ -1,15 +1,20 @@
-apiVersion: config/v2
-kind: config
-
+# metadata contains broad analysis configuration beyond the identification of
+# key taint-propagation elements.
+# These are intended as examples, not necessarily intended to represent explicit intent.
 metadata:
+  # For instance, a flag to warn if a spec would identify no elements, suggesting configuration is stale.
   validateConfig: true
+  # Analysis runs on the transitive closure of import dependencies.
+  # We may wish to explicitly skip those packages which import "testing" or have been otherwise sanctified.
   scope:
     skip:
     - imports: testing
     - package: my/special/pkg
 
+# Identification of taint-propagation elements is done by value or by function call
 source:
 - value:
+    # The specific type and field .../rest.TLSClientConfig.Password is a source
     id: "Core Source"
     package: ^k8s.io/client-go/rest$
     type: ^TLSClientConfig$
@@ -21,9 +26,10 @@ source:
       - myTag: source
       - myTag: otherSource
 - call:
+    # The value returned by os.Getenv("CFSSL_CA_PK_PASSWORD") is sensitive
     id: "sensitive environment information"
     package: os
-    function: getEnv
+    function: Getenv
     arguments:
     - value:
         position: 0
@@ -43,6 +49,8 @@ sink:
     type: MySinker
     field: SinkField
 
+# An allow-list is distinct from an identification's .unless field in intent
+# This allow-list represents false-positive suppression, not intended avoidance.
 allowlist:
 - call:
     <<: *println-sink                        # YAML Anchor expansion sets 'id', 'package', 'function', 'unless'

--- a/internal/pkg/config/testdata/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/test-config-v2.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # metadata contains broad analysis configuration beyond the identification of
 # key taint-propagation elements.
 # These are intended as examples, not necessarily intended to represent explicit intent.

--- a/internal/pkg/config/testdata/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/test-config-v2.yaml
@@ -1,0 +1,55 @@
+apiVersion: config/v2
+kind: config
+
+metadata:
+  validate-config: true
+  pointer-analysis: true
+  scope:
+    skip:
+    - imports: testing
+    - package: my/special/pkg
+
+source:
+- value:
+    id: "Password field"
+    package: ^k8s.io/client-go/rest$
+    type: ^TLSClientConfig$
+    field: Password
+- value:
+    # `levee:”source”` should be default, but additional tags
+    # should be configurable
+    fieldTag: myTag:"source"
+- call:
+    id: "sensitive environment information"
+    package: os
+    function: getEnv
+    argument:
+    - value:
+        position: 0
+        const: CFSSL_CA_PK_PASSWORD
+
+sink:
+- call:  &println-sink
+    id: "don't print"
+    package: fmt
+    function: Println
+    unless:
+      context:
+        package: my/sanctioned/package
+- value:
+    id: "Sink function member"
+    package: path/to/my/sinker/pkg
+    type: MySinker
+    field: SinkField
+
+allowlist:
+- call: *println-sink
+  context:
+    package:  third_party/pkg
+    function: falsePositiveProducer
+- spec:
+    id: "Sink function member"
+    context:
+      package: path/to/my/sinker/pkg
+      function: SafeSink
+      receiver: MySinker

--- a/internal/pkg/config/testdata/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/test-config-v2.yaml
@@ -27,7 +27,7 @@ metadata:
     - package: my/special/pkg
 
 # Identification of taint-propagation elements is done by value or by function call
-source:
+sources:
 - value:
     # The specific type and field .../rest.TLSClientConfig.Password is a source
     id: "Core Source"
@@ -50,7 +50,7 @@ source:
         position: 0
         const: CFSSL_CA_PK_PASSWORD
 
-sink:
+sinks:
 - call:  &println-sink
     id: "don't print"
     package: fmt

--- a/internal/pkg/config/testdata/test-config-v2.yaml
+++ b/internal/pkg/config/testdata/test-config-v2.yaml
@@ -2,8 +2,7 @@ apiVersion: config/v2
 kind: config
 
 metadata:
-  validate-config: true
-  pointer-analysis: true
+  validateConfig: true
   scope:
     skip:
     - imports: testing
@@ -25,7 +24,7 @@ source:
     id: "sensitive environment information"
     package: os
     function: getEnv
-    argument:
+    arguments:
     - value:
         position: 0
         const: CFSSL_CA_PK_PASSWORD
@@ -36,8 +35,8 @@ sink:
     package: fmt
     function: Println
     unless:
-      context:
-        package: my/sanctioned/package
+      - context:
+          package: my/sanctioned/package
 - value:
     id: "Sink function member"
     package: path/to/my/sinker/pkg
@@ -45,11 +44,13 @@ sink:
     field: SinkField
 
 allowlist:
-- call: *println-sink
-  context:
-    package:  third_party/pkg
-    function: falsePositiveProducer
-- spec:
+- call:
+    <<: *println-sink                        # YAML Anchor expansion sets 'id', 'package', 'function', 'unless'
+    id: "Ignore prints in third_party/pkg"   # overwrite 'id'
+    context:                                 # add context
+      package:  third_party/pkg
+      function: falsePositiveProducer
+- call:
     id: "Sink function member"
     context:
       package: path/to/my/sinker/pkg

--- a/internal/pkg/sourcetype/analyzer.go
+++ b/internal/pkg/sourcetype/analyzer.go
@@ -135,7 +135,7 @@ func exportSourceFacts(pass *analysis.Pass, ssaType *ssa.Type, conf *config.Conf
 			if fld.Pkg() != pass.Pkg {
 				continue
 			}
-			if conf.IsSourceField(ssaType.Type(), fld) || taggedFields.IsSource(fld) {
+			if conf.IsSourceField(ssaType.Type(), fld, taggedFields) {
 				pass.ExportObjectFact(fld, &fieldDeclFact{})
 			}
 		}

--- a/internal/pkg/sourcetype/analyzer.go
+++ b/internal/pkg/sourcetype/analyzer.go
@@ -135,7 +135,7 @@ func exportSourceFacts(pass *analysis.Pass, ssaType *ssa.Type, conf *config.Conf
 			if fld.Pkg() != pass.Pkg {
 				continue
 			}
-			if conf.IsSourceField(ssaType.Type(), fld, taggedFields) {
+			if conf.IsSourceField(ssaType.Type(), fld) || taggedFields.IsSource(fld) {
 				pass.ExportObjectFact(fld, &fieldDeclFact{})
 			}
 		}


### PR DESCRIPTION
This refactor is intended to enable future resolution of #87, #88, #89, #91, #103, i.e. our `label:configuration` issues.

- [x] Tests pass
- [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [ ] Appropriate changes to README are included in PR

===

## Discussion:

### Where should the heavy lifting occur?

Pros and cons of iterating towards `package config` being a simple data container, with actual matching logic being owned by the relevant packages.

* Pro:
  * Keep `ssa` logic where `ssa` is being used, rather than `config` requiring global implementation knowledge
  * Keep `config` "low level," avoiding need to expose excessive number of methods as we add additional configuration features.
* Con:
  * Each package will need to "unpack" configuration, e.g. `source` will need to `for i, s := range cfg.Source { s.Package.Match(mySsa.pkg) // ... }` etc.

I could go either way on it, personally.  A lot of `ssa` logic currently lives in `config`.

I think maybe the ideal option would be to split the difference and to rewrite the current method-set to only take basic types  E.g.
`func (c Config) IsSourceField(packagePath, typeName, fieldName) bool`.  Or maybe to return the set of matchers that satisfy the given constraint.  I'm not sure, and I think this is something that's only going to evince itself as we try to migrate to the new struct.

### What do you think of the example YAML?

@mlevesquedion and I have had some discussion offline about what a decent implementation might look like.  Now having iterated on it, I'd appreciate your and/or other's input on this spec style.  Some key questions:

* Do you want to maintain the name `packageRE`, or have `package` implicitly be a regexp?  Or accept either, using `packageRE` as a regexp patch and `package` as an explicit string match?
* Does the `fieldtags` format of explicitly listing key-value pairs read well?  We could accept a list of tag strings, e.g., `foo:"bar"` as the input, but I worry how that would read / parse in YAML.