### PR TITLE
Add sanity check to automatic detection of test directories.

### DIFF
--- a/internal/pkg/levee/levee_test.go
+++ b/internal/pkg/levee/levee_test.go
@@ -70,6 +70,6 @@ func checkForGoFiles(path string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("found no Go files in test directory (%s).  You may need to run `git clean`.", path)
+	return fmt.Errorf("found no Go files in test directory (%s)", path)
 
 }

--- a/internal/pkg/levee/levee_test.go
+++ b/internal/pkg/levee/levee_test.go
@@ -16,8 +16,10 @@ package internal
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-flow-levee/internal/pkg/debug"
@@ -46,7 +48,28 @@ func findTestPatterns(t *testing.T, testsDir string) (patterns []string) {
 		t.Fatalf("Failed to read tests dir (%s): %v", testsDir, err)
 	}
 	for _, f := range files {
-		patterns = append(patterns, filepath.Join(testsDir, f.Name()))
+		path := filepath.Join(testsDir, f.Name())
+		// Make sure the directory contains a go file to avoid failure on empty directories.
+		if err := checkForGoFiles(path); err != nil {
+			t.Fatalf("Could not verify presence of Go files in test directory: %v", err)
+		}
+
+		patterns = append(patterns, path)
 	}
 	return
+}
+
+func checkForGoFiles(path string) error {
+	pkgFiles, err := ioutil.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("failed to examine test directory (%s): %v", path, err)
+	}
+
+	for _, file := range pkgFiles {
+		if strings.HasSuffix(file.Name(), ".go") {
+			return nil
+		}
+	}
+	return fmt.Errorf("found no Go files in test directory (%s).  You may need to run `git clean`.", path)
+
 }


### PR DESCRIPTION
There is an awkward interaction between `git` and the implicit building of packages for testing from `testdata` directories.

Because `git` only tracks files, not directories, it is possible after changing branches to have an empty directory after `git` has moved or deleted files.  Because we assume that every folder in `testdata` can be converted into an associated Go package, testing fails when it finds an empty directory in testdata.

This PR examines test directories for Go files and produces a more helpful error message if any are empty.

Test locally with `mkdir .../go-flow-levee/internal/pkg/levee/testdata/src/example.com/tests/empty`.  

- [x] Tests pass
- [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [ ] Appropriate changes to README are included in PR