### PR TITLE
Add tests for select statements

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/changeint/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/changeint/tests.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changeint
+
+import (
+	"example.com/core"
+)
+
+type empty interface {
+}
+
+func TestChangeInterface(s core.Source) {
+	var in interface{} = s
+	var em empty = in
+	core.Sink(em) // want "a source has reached a sink"
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/select/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/select/tests.go
@@ -1,0 +1,148 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sel
+
+import (
+	"example.com/core"
+)
+
+func TestSelectSourceSingleCase(sources <-chan core.Source) {
+	// In the ssa, a single case select is equivalent to not having a select at all.
+	select {
+	case s := <-sources:
+		core.Sink(s) // want "a source has reached a sink"
+	}
+}
+
+func TestSelectSourceDefault(sources <-chan core.Source) {
+	select {
+	case s := <-sources:
+		core.Sink(s) // want "a source has reached a sink"
+	default:
+		return
+	}
+}
+
+func TestSelectSourcePointer(sources <-chan *core.Source) {
+	select {
+	case s := <-sources:
+		core.Sink(s) // want "a source has reached a sink"
+	default:
+		return
+	}
+}
+
+func TestTaintChannelInParameter(objects chan interface{}) {
+	objects <- core.Source{}
+	select {
+	case s := <-objects:
+		core.Sink(s) // want "a source has reached a sink"
+	default:
+	}
+}
+
+func TestTaintChannelMadeLocally() {
+	objects := make(chan interface{}, 1)
+
+	objects <- core.Source{}
+
+	select {
+	case s := <-objects:
+		core.Sink(s) // TODO want "a source has reached a sink"
+	default:
+	}
+}
+
+func TestTaintedInOneSelectSinkedInTheNext() {
+	objects := make(chan interface{}, 1)
+
+	select {
+	case objects <- core.Source{}:
+	default:
+	}
+
+	select {
+	case s := <-objects:
+		core.Sink(s) // TODO want "a source has reached a sink"
+	default:
+	}
+}
+
+func TestTaintedAndSinkedInDifferentBranches(objects chan interface{}) {
+	select {
+	case objects <- core.Source{}:
+	case s := <-objects:
+		// we do not expect a report here, because objects is only tainted if the
+		// other branch is taken, and only one branch can be taken
+		// TODO core.Sink(s)
+		_ = s
+	}
+}
+
+func TestTaintedAndSinkedInDifferentBranchesInLoop(objects chan interface{}) {
+	for {
+		select {
+		case objects <- core.Source{}:
+		case s := <-objects:
+			core.Sink(s) // want "a source has reached a sink"
+		}
+	}
+}
+
+func TestSelectSourceAndInnoc(sources <-chan core.Source, innocs <-chan core.Innocuous) {
+	select {
+	case s := <-sources:
+		core.Sink(s) // want "a source has reached a sink"
+	case i := <-innocs:
+		core.Sink(i)
+	}
+}
+
+func TestSelectIntoInterface(sources <-chan core.Source, innocs <-chan core.Innocuous) {
+	var empty interface{}
+	select {
+	case empty = <-sources:
+	case empty = <-innocs:
+	}
+	core.Sink(empty) // want "a source has reached a sink"
+}
+
+func TestTaintedInForkedClosure(objects chan interface{}) {
+	go func() {
+		objects <- core.Source{}
+	}()
+
+	select {
+	case s := <-objects:
+		core.Sink(s) // TODO want "a source has reached a sink"
+	default:
+		return
+	}
+}
+
+func TestTaintedInForkedCall(objects chan interface{}) {
+	go PutSource(objects)
+
+	select {
+	case s := <-objects:
+		core.Sink(s) // TODO want "a source has reached a sink"
+	default:
+		return
+	}
+}
+
+func PutSource(objects chan<- interface{}) {
+	objects <- core.Source{}
+}


### PR DESCRIPTION
This PR adds tests covering select statements.

Some cases are currently failing, I am investigating why that is the case. 

Some cases involve interprocedural interactions and are not expected to pass.

- [x] Tests pass
- [] (N/A) Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [] (N/A) Appropriate changes to README are included in PR