### PR TITLE
Do not traverse to lookup index

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/callorder/beforesource.go
@@ -52,3 +52,15 @@ func TestDoesNotReachSinkInIfBeforeSourceThroughValueCreatedBeforeSource() {
 
 	_ = map[string]core.Source{}[k.name]
 }
+
+func TestValueDeclaredBeforeSourceIsTainted() {
+	var x interface{} = core.Innocuous{}
+	x = core.Source{}
+	core.Sink(x) // want "a source has reached a sink"
+}
+
+func TestSliceDeclaredBeforeSourceIsTainted() {
+	xs := []interface{}{nil}
+	xs[0] = core.Source{}
+	core.Sink(xs) // want "a source has reached a sink"
+}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -223,8 +223,9 @@ func (s *Source) visitOperands(from ssa.Node, operands []*ssa.Value, maxInstrRea
 			}
 		}
 
-		// don't traverse to the key in a lookup
-		// if a map is tainted, looking up a value in the map doesn't taint the key
+		// Don't traverse to the key in a lookup.
+		// For example, if a map is tainted, looking up a value in the map
+		// doesn't taint the key, so we shouldn't traverse to the key.
 		if look, ok := from.(*ssa.Lookup); ok && *o == look.Index {
 			continue
 		}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -97,9 +97,6 @@ func (s *Source) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBl
 	}
 
 	if instr, ok := n.(ssa.Instruction); ok {
-		if !s.reachableFromSource(instr) {
-			return
-		}
 		// If the referrer is in a different block from the one we last visited,
 		// and it can't be reached from the block we are visiting, then stop visiting.
 		if ib := instr.Block(); lastBlockVisited != nil &&
@@ -172,33 +169,6 @@ func (s *Source) referrersToVisit(n ssa.Node, maxInstrReached map[*ssa.BasicBloc
 	return referrers
 }
 
-func (s *Source) reachableFromSource(target ssa.Instruction) bool {
-	// If the Source isn't produced by an instruction, be conservative and
-	// assume the target instruction is reachable.
-	sInstr, ok := s.node.(ssa.Instruction)
-	if !ok {
-		return true
-	}
-
-	// If these calls fail, be conservative and assume the target
-	// instruction is reachable.
-	sIndex, sOk := indexInBlock(sInstr)
-	targetIndex, targetOk := indexInBlock(target)
-	if !sOk || !targetOk {
-		return true
-	}
-
-	if sInstr.Block() == target.Block() && sIndex > targetIndex {
-		return false
-	}
-
-	if !s.canReach(sInstr.Block(), target.Block()) {
-		return false
-	}
-
-	return true
-}
-
 func (s *Source) canReach(start *ssa.BasicBlock, dest *ssa.BasicBlock) bool {
 	if start.Dominates(dest) {
 		return true
@@ -222,7 +192,7 @@ func (s *Source) canReach(start *ssa.BasicBlock, dest *ssa.BasicBlock) bool {
 	return false
 }
 
-func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (s *Source) visitOperands(from ssa.Node, operands []*ssa.Value, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
 	// Do not visit Operands if the current node is an Extract.
 	// This is to avoid incorrectly tainting non-Source values that are
 	// produced by an Instruction that has a Source among the values it
@@ -230,7 +200,7 @@ func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReache
 	// func NewSource() (*core.Source, error)
 	// Which leads to a flow like:
 	// Extract (*core.Source) --> Call (NewSource) --> error
-	if _, ok := n.(*ssa.Extract); ok {
+	if _, ok := from.(*ssa.Extract); ok {
 		return
 	}
 
@@ -251,6 +221,12 @@ func (s *Source) visitOperands(n ssa.Node, operands []*ssa.Value, maxInstrReache
 			if _, isArray := utils.Dereference(al.Type()).(*types.Array); !isArray {
 				continue
 			}
+		}
+
+		// don't traverse to the key in a lookup
+		// if a map is tainted, looking up a value in the map doesn't taint the key
+		if look, ok := from.(*ssa.Lookup); ok && *o == look.Index {
+			continue
 		}
 		s.dfs(n, maxInstrReached, lastBlockVisited)
 	}


### PR DESCRIPTION
This PR fixes an issue where in some cases we aren't traversing to values that we should be traversing to.

Specifically, consider this case:
```go
func Test() {
	xs := []interface{}{nil}
	xs[0] = core.Source{}
	core.Sink(xs) // want "a source has reached a sink"
}
```
This test case is actually failing right now because of the following check in `reachableFromSource`:
```go
if sInstr.Block() == target.Block() && sIndex > targetIndex {
        return false
} 
```
In summary: if the target instruction occurs before the Source-producing instruction, then the target instruction is not reachable from the source (so don't traverse to it).

This test case was added to prevent an unexpected report in this case:
```go
func TestDoesNotReachSinkAfterSourceThroughValueCreatedBeforeSource() {
	// Taint should not propagate to this value.
	k := newKey()

	_ = map[string]core.Source{}[k.name]

	core.Sink(k.Name())
}
```

It seems that the "fix" that I did in `reachableFromSource` was a little excessive. To handle this case properly, it suffices to avoid traversing to the `Index` in a `Lookup`. Indeed, looking up a value in a tainted map does not taint the key (e.g.).

I'm not sure what other test cases might be good to have. There are probably other cases in which we want to avoid incorrect propagation, but due to the risk of false negatives I think it is best to remove `reachableFromSource` altogether for now. (Removing it fails no tests).

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [x] Appropriate changes to README are included in PR