### PR TITLE
Use test glob to run all tests

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -63,10 +63,5 @@ func TestConfig(t *testing.T) {
 	if err := FlagSet.Set("config", filepath.Join(testdata, "test-config.yaml")); err != nil {
 		t.Fatal(err)
 	}
-	for _, p := range []string{"core", "crosspkg", "exclusion", "notcore"} {
-		analysistest.Run(t, testdata, testAnalyzer, filepath.Join(testdata, "src/example.com", p))
-	}
-	for _, p := range []string{"core", "exclusion"} {
-		analysistest.Run(t, testdata, testAnalyzer, filepath.Join(testdata, "src/notexample.com", p))
-	}
+	analysistest.Run(t, testdata, testAnalyzer, "./...")
 }

--- a/internal/pkg/fieldpropagator/analyzer_test.go
+++ b/internal/pkg/fieldpropagator/analyzer_test.go
@@ -27,5 +27,5 @@ func TestFieldPropagatorAnalysis(t *testing.T) {
 	if err := config.FlagSet.Set("config", filepath.Join(testdata, "test-config.yaml")); err != nil {
 		t.Error(err)
 	}
-	analysistest.Run(t, testdata, Analyzer, "source", "test")
+	analysistest.Run(t, testdata, Analyzer, "./...")
 }

--- a/internal/pkg/fieldtags/analyzer_test.go
+++ b/internal/pkg/fieldtags/analyzer_test.go
@@ -31,7 +31,7 @@ func TestFieldTagsAnalysis(t *testing.T) {
 		t.Error(err)
 	}
 
-	results := analysistest.Run(t, testdata, Analyzer, "tests")
+	results := analysistest.Run(t, testdata, Analyzer, "./...")
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))

--- a/internal/pkg/levee/levee_test.go
+++ b/internal/pkg/levee/levee_test.go
@@ -16,10 +16,6 @@ package internal
 
 import (
 	"flag"
-	"fmt"
-	"io/ioutil"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-flow-levee/internal/pkg/debug"
@@ -33,43 +29,8 @@ func TestLevee(t *testing.T) {
 	if err := Analyzer.Flags.Set("config", dataDir+"/test-config.yaml"); err != nil {
 		t.Error(err)
 	}
-	testsDir := filepath.Join(dataDir, "src/example.com/tests")
-	patterns := findTestPatterns(t, testsDir)
 	if *debugging {
 		Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
 	}
-	analysistest.Run(t, dataDir, Analyzer, patterns...)
-}
-
-func findTestPatterns(t *testing.T, testsDir string) (patterns []string) {
-	t.Helper()
-	files, err := ioutil.ReadDir(testsDir)
-	if err != nil {
-		t.Fatalf("Failed to read tests dir (%s): %v", testsDir, err)
-	}
-	for _, f := range files {
-		path := filepath.Join(testsDir, f.Name())
-		// Make sure the directory contains a go file to avoid failure on empty directories.
-		if err := checkForGoFiles(path); err != nil {
-			t.Fatalf("Could not verify presence of Go files in test directory: %v", err)
-		}
-
-		patterns = append(patterns, path)
-	}
-	return
-}
-
-func checkForGoFiles(path string) error {
-	pkgFiles, err := ioutil.ReadDir(path)
-	if err != nil {
-		return fmt.Errorf("failed to examine test directory (%s): %v", path, err)
-	}
-
-	for _, file := range pkgFiles {
-		if strings.HasSuffix(file.Name(), ".go") {
-			return nil
-		}
-	}
-	return fmt.Errorf("found no Go files in test directory (%s)", path)
-
+	analysistest.Run(t, dataDir, Analyzer, "./...")
 }

--- a/internal/pkg/sourceinfer/analyzer_test.go
+++ b/internal/pkg/sourceinfer/analyzer_test.go
@@ -29,7 +29,5 @@ func TestInferAnalysis(t *testing.T) {
 		t.Error(err)
 	}
 
-	for _, testPkg := range []string{"core", "crosspkg", "samepkg", "nosource"} {
-		analysistest.Run(t, testdata, Analyzer, filepath.Join(testdata, "src/example.com/tests", testPkg))
-	}
+	analysistest.Run(t, testdata, Analyzer, "./...")
 }

--- a/internal/pkg/sourcetype/analyzer_test.go
+++ b/internal/pkg/sourcetype/analyzer_test.go
@@ -28,5 +28,5 @@ func TestSourceAnalysis(t *testing.T) {
 		return
 	}
 
-	analysistest.Run(t, testdata, Analyzer, "sourcetype", "crosspkg")
+	analysistest.Run(t, testdata, Analyzer, "./...")
 }


### PR DESCRIPTION
This PR is in response to discussion on #170.

In packages where we just want to run all the tests, we can get away with using a `./...` pattern to catch all the test files.

- [x] Tests pass
- (N/A) [] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [] Appropriate changes to README are included in PR