### PR TITLE
Do not infer sources from functions

### DIFF
--- a/internal/pkg/sourceinfer/analyzer.go
+++ b/internal/pkg/sourceinfer/analyzer.go
@@ -154,9 +154,10 @@ func findObjects(t types.Type) map[types.Object]bool {
 			traverse(tt.Elem())
 		case *types.Struct:
 			for i := 0; i < tt.NumFields(); i++ {
+				f := tt.Field(i)
 				// The field itself could be a source, e.g. in the case of a tagged field.
-				objects[tt.Field(i)] = true
-				traverse(tt.Field(i).Type())
+				objects[f] = true
+				traverse(f.Type())
 			}
 		case *types.Basic, *types.Tuple, *types.Interface, *types.Signature:
 			// these do not contain relevant objects

--- a/internal/pkg/sourceinfer/analyzer.go
+++ b/internal/pkg/sourceinfer/analyzer.go
@@ -137,27 +137,26 @@ func createObjectGraph(pass *analysis.Pass, ins *inspector.Inspector) objectGrap
 func findObjects(t types.Type) map[types.Object]bool {
 	objects := map[types.Object]bool{}
 
-	// find traverses a type to add relevant objects to the objects map.
-	var find func(t types.Type)
-	find = func(t types.Type) {
+	var traverse func(t types.Type)
+	traverse = func(t types.Type) {
 		deref := utils.Dereference(t)
 		switch tt := deref.(type) {
 		case *types.Named:
 			objects[tt.Obj()] = true
 		case *types.Array:
-			find(tt.Elem())
+			traverse(tt.Elem())
 		case *types.Slice:
-			find(tt.Elem())
+			traverse(tt.Elem())
 		case *types.Chan:
-			find(tt.Elem())
+			traverse(tt.Elem())
 		case *types.Map:
-			find(tt.Key())
-			find(tt.Elem())
+			traverse(tt.Key())
+			traverse(tt.Elem())
 		case *types.Struct:
 			for i := 0; i < tt.NumFields(); i++ {
 				// The field itself could be a source, e.g. in the case of a tagged field.
 				objects[tt.Field(i)] = true
-				find(tt.Field(i).Type())
+				traverse(tt.Field(i).Type())
 			}
 		case *types.Basic, *types.Tuple, *types.Interface, *types.Signature:
 			// these do not contain relevant objects
@@ -169,7 +168,7 @@ func findObjects(t types.Type) map[types.Object]bool {
 		}
 	}
 
-	find(t)
+	traverse(t)
 
 	return objects
 }

--- a/internal/pkg/sourceinfer/analyzer.go
+++ b/internal/pkg/sourceinfer/analyzer.go
@@ -114,72 +114,16 @@ func createObjectGraph(pass *analysis.Pass, ins *inspector.Inspector) objectGrap
 
 		typeBeingDefined := pass.TypesInfo.ObjectOf(ts.Name)
 
-		// Find selector expressions and add them to the graph.
-		// We need to look at SelectorExprs first, because they
-		// contain identifiers, e.g. foo.Bar contains the identifiers
-		// foo (qualifying package) and Bar (unqualified type).
-		// We need to look at the whole expression in order to resolve
-		// the type correctly.
-		selectorFinder := &selectorFinder{nil, map[*ast.Ident]bool{}}
-		ast.Walk(selectorFinder, (ast.Node)(ts.Type))
-		for _, sel := range selectorFinder.foundSelectors {
-			named, ok := pass.TypesInfo.TypeOf(sel).(*types.Named)
-			if !ok {
-				continue
-			}
-			obj := named.Obj()
-			objGraph[obj] = append(objGraph[obj], typeBeingDefined)
-		}
-
-		// Find identifiers that aren't in selector expressions
-		// and add them to the graph.
-		idFinder := &identFinder{}
-		ast.Walk(idFinder, (ast.Node)(ts.Type))
-		for _, id := range idFinder.foundIdentifiers {
-			// identifier is part of a SelectorExpr and has already been handled
-			if selectorFinder.foundIdentifiers[id] {
-				continue
-			}
-			obj := pass.TypesInfo.ObjectOf(id)
-			objGraph[obj] = append(objGraph[obj], typeBeingDefined)
+		for n := range findNamedTypes(pass.TypesInfo.TypeOf(ts.Type)) {
+			objGraph[n.Obj()] = append(objGraph[n.Obj()], typeBeingDefined)
 		}
 	})
 
 	return objGraph
 }
 
-type selectorFinder struct {
-	foundSelectors   []*ast.SelectorExpr
-	foundIdentifiers map[*ast.Ident]bool
-}
-
-func (sf *selectorFinder) Visit(n ast.Node) ast.Visitor {
-	sel, ok := n.(*ast.SelectorExpr)
-	if !ok {
-		return sf
-	}
-	pkg, ok := sel.X.(*ast.Ident)
-	if !ok {
-		return nil
-	}
-	sf.foundSelectors = append(sf.foundSelectors, sel)
-	sf.foundIdentifiers[pkg] = true
-	sf.foundIdentifiers[sel.Sel] = true
-	return nil
-}
-
-type identFinder struct {
-	foundIdentifiers []*ast.Ident
-}
-
-func (i *identFinder) Visit(n ast.Node) ast.Visitor {
-	if id, ok := n.(*ast.Ident); ok {
-		i.foundIdentifiers = append(i.foundIdentifiers, id)
-		return nil
-	}
-	return i
-}
-
+// findNamedTypes finds named types within a type that can potentially be sources.
+// Among other things, this excludes basic types and functions (Signatures).
 func findNamedTypes(t types.Type) map[*types.Named]bool {
 	namedTypes := map[*types.Named]bool{}
 
@@ -198,8 +142,12 @@ func findNamedTypes(t types.Type) map[*types.Named]bool {
 		case *types.Map:
 			find(tt.Key())
 			find(tt.Elem())
-		case *types.Basic, *types.Struct, *types.Tuple, *types.Interface, *types.Signature:
-			// these types cannot hold named types
+		case *types.Struct:
+			for i := 0; i < tt.NumFields(); i++ {
+				find(tt.Field(i).Type())
+			}
+		case *types.Basic, *types.Tuple, *types.Interface, *types.Signature:
+			// these do not contain relevant named types
 		case *types.Pointer:
 			// this should be unreachable due to the dereference above
 		default:

--- a/internal/pkg/sourceinfer/testdata/src/example.com/tests/core/field.go
+++ b/internal/pkg/sourceinfer/testdata/src/example.com/tests/core/field.go
@@ -53,6 +53,14 @@ type (
 	NotSourceHolder struct {
 		ns source.NotSource
 	}
+
+	FieldFuncWithSourceArg struct {
+		f func(s source.Source)
+	}
+
+	FieldFuncWithSourceRetval struct {
+		f func() source.Source
+	}
 )
 
 func Field() {

--- a/internal/pkg/sourceinfer/testdata/src/example.com/tests/core/typedef.go
+++ b/internal/pkg/sourceinfer/testdata/src/example.com/tests/core/typedef.go
@@ -29,7 +29,8 @@ type (
 )
 
 type (
-	NotDefinedSource source.NotSource
+	NotDefinedSource       source.NotSource
+	FunctionsAreNotSources func() map[string]source.Source
 )
 
 func Typedef() {


### PR DESCRIPTION
This PR prevents named types from being inferred as sources due to holding functions that have source arguments or return values.

As a happy side effect, the implementation of the fix also greatly simplifies the code.

## Context

This PR removes the `ast` visitors that were previously used to find objects. The issue with the visitors is that they were grabbing all `selectors` and `identifiers`, which included those in function type definitions, e.g. the `Source` in `func() Source`. It's possible to avoid those by adding logic to each visitor to stop traversing when they hit an `ast.FuncType` node, but I wasn't too keen to add some duplicated special case behavior, so I looked for a simpler way.

The key insight I had is that we don't actually need to traverse the `ast`. We can find the information we need by "traversing" the type. We already had some code for doing this, i.e. `findNamedTypes`. That code already avoids functions, because it does not traverse through `type.Signatures`, so types within functions aren't an issue. However, it now needs to traverse through `type.Structs` in order to find struct fields, because those can be tagged. Since fields now needed to be handled in this function, it made sense to extract the objects instead of the types. Indeed, we don't want `string` in our graph, but we do want the `types.Var` that represents a `string "levee:\"source\""` field. I think it also makes sense from the client's point of view: the function that creates the object graph is interested in the objects.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR