### PR TITLE
Add range tests

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/arrays.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/arrays.go
@@ -40,3 +40,10 @@ func TestArrayRemainsTaintedWhenSourceIsOverwritten(s core.Source) {
 	arr[0] = nil
 	core.Sink(arr) // want "a source has reached a sink"
 }
+
+func TestRangeOverArray() {
+	sources := [1]core.Source{core.Source{Data: "password1234"}}
+	for _, s := range sources {
+		core.Sink(s) // want "a source has reached a sink"
+	}
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/chans.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/chans.go
@@ -39,3 +39,9 @@ func TestChannelIsNoLongerTaintedWhenNilledOut(sources chan core.Source) {
 	sources = nil
 	core.Sink(sources)
 }
+
+func TestRangeOverChan(sources chan core.Source) {
+	for s := range sources {
+		core.Sink(s) // want "a source has reached a sink"
+	}
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
@@ -52,3 +52,10 @@ func TestMapRemainsTaintedWhenSourceIsDeleted(s core.Source) {
 	delete(m, s)
 	core.Sink(m) // want "a source has reached a sink"
 }
+
+func TestRangeOverMap() {
+	m := map[string]core.Source{"secret": core.Source{Data: "password1234"}}
+	for _, s := range m {
+		core.Sink(s) // want "a source has reached a sink"
+	}
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/slices.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/slices.go
@@ -26,3 +26,10 @@ func TestSlices(s core.Source) {
 	core.Sink([]interface{}{0, "", s})    // want "a source has reached a sink"
 	core.Sink([]interface{}{0, "", s}...) // want "a source has reached a sink"
 }
+
+func TestRangeOverSlice() {
+	sources := []core.Source{core.Source{Data: "password1234"}}
+	for _, s := range sources {
+		core.Sink(s) // want "a source has reached a sink"
+	}
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/slices.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/slices.go
@@ -33,3 +33,9 @@ func TestRangeOverSlice() {
 		core.Sink(s) // want "a source has reached a sink"
 	}
 }
+
+func TestRangeOverInterfaceSlice() {
+	for _, s := range []interface{}{core.Source{Data: "password1235"}} {
+		core.Sink(s) // want "a source has reached a sink"
+	}
+}


### PR DESCRIPTION
This PR adds tests covering range operations over common collections.

Ranging over a slice uses an index. The index is compared with the length of the slice to determine when to stop. (Ranging over an array is pretty much identical, except that the length is known in advance).

Ranging over a map uses an iterator created with the `Range` instruction. The next element is obtained with the `Next` instruction.

Ranging over a channel uses an implicit `x, ok := <-chan` operation to determine when to stop.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR