### PR TITLE
Refactor: move result decls closer to usage

### DIFF
--- a/internal/pkg/sourceinfer/analyzer.go
+++ b/internal/pkg/sourceinfer/analyzer.go
@@ -87,10 +87,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
-	ft := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
-
 	objectGraph := createObjectGraph(pass, ins)
 
+	ft := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
 	inferredSources := inferSources(pass, conf, ft, objectGraph)
 
 	return inferredSources, nil


### PR DESCRIPTION
A small refactoring for clarity. 

Moving declarations for analyzer results closer to where they are used to make it clearer which result is used in which step of the algorithm.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR