### PR TITLE
Add missing BinOp test

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/binop/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/binop/tests.go
@@ -20,7 +20,7 @@ import (
 	"example.com/core"
 )
 
-func TestConcatenatingTaintedAndNonTainteStrings(prefix string) {
+func TestConcatenatingTaintedAndNonTaintedStrings(prefix string) {
 	s := core.Source{Data: "password1234"}
 	message := fmt.Sprintf("source: %v", s)
 	fullMessage := prefix + message

--- a/internal/pkg/levee/testdata/src/example.com/tests/binop/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/binop/tests.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binop
+
+import (
+	"fmt"
+
+	"example.com/core"
+)
+
+func TestConcatenatingTaintedAndNonTainteStrings(prefix string) {
+	s := core.Source{Data: "password1234"}
+	message := fmt.Sprintf("source: %v", s)
+	fullMessage := prefix + message
+	// TODO: no report should be produced for "prefix"
+	core.Sink(prefix)      // want "a source has reached a sink"
+	core.Sink(message)     // want "a source has reached a sink"
+	core.Sink(fullMessage) // want "a source has reached a sink"
+}


### PR DESCRIPTION
Currently, we are propagating to all `Operands` + `Referrers` of `BinOp`s. This means that if one `Operand` of a `BinOp` is tainted, we will propagate to the other `Operand`. Doing so never makes sense. Indeed, according to the `ssa` documentation for `BinOp`, the operation can be one of the following:

```go
	// ADD SUB MUL QUO REM          + - * / %
	// AND OR XOR SHL SHR AND_NOT   & | ^ << >> &^
	// EQL NEQ LSS LEQ GTR GEQ      == != < <= < >=
```

(To my knowledge) All of these operations produce new values, so taint cannot propagate to the other operand if one of the operands is tainted. It should only propagate to the result.

This PR introduces a failing test that demonstrates the erroneous behavior. This behavior could be fixed via a special case in the current code, or via the explicit handling proposed in #178.

## Additional comments

For this test to work, `prefix` has to be a parameter. Otherwise, `ssa` inlines the string everywhere, which prevents any propagation from happening.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR