### PR TITLE
Add missing Phi test

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/phi/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/phi/tests.go
@@ -32,3 +32,13 @@ func TestPhiNodeDoesntPropagateTaintToOperands(i *core.Innocuous) {
 		core.Sink(ss) // want "a source has reached a sink"
 	}
 }
+
+func TestPhiNodeIsTaintedByTaintedOperand(s core.Source, i *core.Innocuous) {
+	var ss, ii interface{} = s, i
+	if true {
+		ii = ss
+	}
+	core.Sink(ss) // want "a source has reached a sink"
+	core.Sink(ii) // want "a source has reached a sink"
+	core.Sink(i)
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/phi/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/phi/tests.go
@@ -18,15 +18,17 @@ import (
 	"example.com/core"
 )
 
-func TestPhiNodeWithTaintedAndNonTaintedOperands(i *core.Innocuous) {
+func TestPhiNodeDoesntPropagateTaintToOperands(i *core.Innocuous) {
 	for {
 		s := core.Source{}
-		var x, y interface{} = s, i
+		var ss, ii interface{} = s, i
 		if true {
-			x = y
+			ss = ii
 		}
+		// TODO: no report should be produced for ii
+		core.Sink(ii) // want "a source has reached a sink"
 		// TODO: no report should be produced for i
-		core.Sink(i) // want "a source has reached a sink"
-		core.Sink(x) // want "a source has reached a sink"
+		core.Sink(i)  // want "a source has reached a sink"
+		core.Sink(ss) // want "a source has reached a sink"
 	}
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/phi/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/phi/tests.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phi
+
+import (
+	"example.com/core"
+)
+
+func TestPhiNodeWithTaintedAndNonTaintedOperands(i *core.Innocuous) {
+	for {
+		s := core.Source{}
+		var x, y interface{} = s, i
+		if true {
+			x = y
+		}
+		// TODO: no report should be produced for i
+		core.Sink(i) // want "a source has reached a sink"
+		core.Sink(x) // want "a source has reached a sink"
+	}
+}


### PR DESCRIPTION
This PR is very similar to #179, but it adds a test for a different kind of `Instruction`.

Currently, we are propagating to all `Operands` + `Referrers` of `Phi` nodes. This means that if one Operand of a Phi is tainted, we will propagate to the other Operand(s). Doing so never makes sense. Indeed, a `Phi` node is a decision point where (during execution) the value that should be used is determined by the path that was taken. If one of the possible values is tainted, we cannot conclude that any of the other values is tainted.

This PR introduces a failing test that demonstrates the erroneous behavior. This behavior could be fixed via a special case in the current code, or via the explicit handling proposed in #178.

## Why is the test so convoluted?

Some traversal behaviors, not directly related to `Phi` nodes, are already affording us some amount of protection against incorrect traversals :
* We don't traverse through `Alloc`s, except if they are allocating arrays. This is why the untainted operand is a pointer (pointers don't have Allocs). Since it is a pointer, making it a parameter means it won't be replaced by an explicit `nil` (which would get inlined everywhere, preventing any propagation from occurring).
* We don't traverse to instructions that are in a block that isn't reachable from the current instruction's block. This is why all the instructions are in a `for` loop, it makes every block reachable from every other block.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR