### PR TITLE
Add missing map tests

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
@@ -53,19 +53,19 @@ func TestMapRemainsTaintedWhenSourceIsDeleted(s core.Source) {
 	core.Sink(m) // want "a source has reached a sink"
 }
 
-func TestMapDeleteDoesNotTaintTheKey(key string, sources map[string]core.Source) {
+func TestDeletingFromTaintedMapDoesNotTaintTheKey(key string, sources map[string]core.Source) {
 	delete(sources, key)
 	// TODO: no report should be produced here
 	core.Sink(key) // want "a source has reached a sink"
 }
 
-func TestMapUpdateDoesNotTaintTheKey(key string, value core.Source, sources map[string]core.Source) {
+func TestMapUpdateWithTaintedValueDoesNotTaintTheKey(key string, value core.Source, sources map[string]core.Source) {
 	sources[key] = value
 	// TODO: no report should be produced here
 	core.Sink(key) // want "a source has reached a sink"
 }
 
-func TestMapUpdateDoesNotTaintTheValue(key core.Source, value string, sources map[core.Source]string) {
+func TestMapUpdateWithTaintedKeyDoesNotTaintTheValue(key core.Source, value string, sources map[core.Source]string) {
 	sources[key] = value
 	// TODO: no report should be produced here
 	core.Sink(value) // want "a source has reached a sink"

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
@@ -52,3 +52,21 @@ func TestMapRemainsTaintedWhenSourceIsDeleted(s core.Source) {
 	delete(m, s)
 	core.Sink(m) // want "a source has reached a sink"
 }
+
+func TestMapDeleteDoesNotTaintTheKey(key string, sources map[string]core.Source) {
+	delete(sources, key)
+	// TODO: no report should be produced here
+	core.Sink(key) // want "a source has reached a sink"
+}
+
+func TestMapUpdateDoesNotTaintTheKey(key string, value core.Source, sources map[string]core.Source) {
+	sources[key] = value
+	// TODO: no report should be produced here
+	core.Sink(key) // want "a source has reached a sink"
+}
+
+func TestMapUpdateDoesNotTaintTheValue(key core.Source, value string, sources map[core.Source]string) {
+	sources[key] = value
+	// TODO: no report should be produced here
+	core.Sink(value) // want "a source has reached a sink"
+}


### PR DESCRIPTION
This PR adds (currently failing) tests for `MapUpdate` as well as the `delete` operation on maps.

Specifically, this adds three (negative) cases:
* Deleting a key (`delete(map, key)`) from a map does not taint the key
* Updating a map with a tainted value (`map[key] = value`) does not taint the key
* Updating a map with a tainted key (`map[key] = value`) does not taint the value

The first case exercises some behavior involving `Call` instructions.

The 2nd and 3rd cases validate that when propagating to a `MapUpdate` operation, only the `Map` is tainted (the positive case is already covered by other tests).

This PR is a precursor to #178.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR