### PR TITLE
Allow configuration via regexp or string literals.

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -18,7 +18,7 @@ You may specify these with a combination of string literals or regexp.
 Use `Package`, `Type`, and `Field` to specify by string literal.
 Use `PackageRE`, `TypeRE`, and `FieldRE` to specify by regexp.
 If neither a literal nor a regexp is provided, a wildcard matcher is assumed.
-Providing both a literal and a regexp matcher is considered misconfiguration and will error.
+Providing both a literal and a regexp matcher is considered a misconfiguration and will error.
 
 ```yaml
 Sources:
@@ -46,7 +46,7 @@ As with source configuration, these may be specified by either a provided string
 Use `Package`, `Receiver`, and `Method` to specify by string literal.
 Use `PackageRE`, `ReceiverRE`, and `MethodRE` to specify by regexp.
 If neither a literal nor a regexp is provided, a wildcard matcher is assumed.
-Providing both a literal and a regexp matcher is considered misconfiguration and will error.
+Providing both a literal and a regexp matcher is considered a misconfiguration and will error.
 
 ```yaml
 Sinks:

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -55,8 +55,8 @@ Sinks:
   Method: "Sink"  # Match only functions named exactly "Sink"
 Sanitizers:
 - # Neither Package nor PackageRE is provided - match any package
-  ReceiverRE: "Safe
-  Method: "mySanitizer"
+  ReceiverRE: "^Safe"  # Match any receiver beginning with "Safe"
+  Method: "sanitize"  # Match methods named exactly "sanitize"
 ```
 
 To explicitly match an empty string, such as top-level functions without a receiver, explicitly configure an empty string matcher, e.g., `Receiver: ""`.
@@ -73,7 +73,7 @@ Exclude:
   MethodRE: "^my.*"
 ```
 
-The above will match the function beginning with "my" in the `myproject/mypackage` package.
+The above will match any function beginning with "my" in the `myproject/mypackage` package.
 Since no receiver matcher was provided, it will match any method beginning with "my" bound to any (or no) receiver.
 
 As just two examples, this may be used to avoid analyzing test code, or to suppress "false positive" reports.

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -133,7 +133,7 @@ func (lm literalMatcher) MatchString(s string) bool {
 
 type vacuousMatcher struct{}
 
-func (vacuousMatcher) MatchString(s string) bool {
+func (vacuousMatcher) MatchString(string) bool {
 	return true
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -248,13 +248,6 @@ func (fm funcMatcher) MatchFunction(path, receiver, name string) bool {
 	return fm.Package.MatchString(path) && fm.Receiver.MatchString(receiver) && fm.Method.MatchString(name)
 }
 
-// TODO This is a terrible name.  matchAnyOrNil is not better.
-// Matches match against a string literal or regexp.
-// Returns vacuous true when both matchers are nil.
-func matchEither(literal *string, r *regexp.Regexp, match string) bool {
-	return literal == nil && r == nil || literal != nil && *literal == match || r != nil && r.MatchString(match)
-}
-
 var readFileOnce sync.Once
 var readConfigCached *Config
 var readConfigCachedErr error

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -185,7 +185,6 @@ func (s *sourceMatcher) UnmarshalJSON(bytes []byte) error {
 		return fmt.Errorf("expected only one of Field, FieldRE to be configured")
 	}
 
-	// Unpack raw object into sourceMatcher
 	*s = sourceMatcher{
 		Package: matcherFrom(raw.Package, raw.PackageRE),
 		Type:    matcherFrom(raw.Type, raw.TypeRE),
@@ -235,7 +234,6 @@ func (fm *funcMatcher) UnmarshalJSON(bytes []byte) error {
 		return fmt.Errorf("expected at most one of Method, MethodRE to be configured")
 	}
 
-	// Unpack raw object into funcMatcher
 	*fm = funcMatcher{
 		Package:  matcherFrom(raw.Package, raw.PackageRE),
 		Receiver: matcherFrom(raw.Receiver, raw.ReceiverRE),

--- a/internal/pkg/config/matcher_test.go
+++ b/internal/pkg/config/matcher_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/internal/pkg/config/matcher_test.go
+++ b/internal/pkg/config/matcher_test.go
@@ -34,6 +34,18 @@ PackageRE: bar`,
 			shouldErrorOnLoad: false, // TODO true
 		},
 		{
+			desc: "Malformed YAML errors gracefully",
+			yaml: `
+PackageRE: "No ending quote`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Malformed regexp errors gracefully",
+			yaml: `
+PackageRE: "(?:NoEndingParen"`,
+			shouldErrorOnLoad: true,
+		},
+		{
 			desc: "Do not permit both Package and PackageRE",
 			yaml: `
 Package: foo
@@ -148,11 +160,23 @@ func TestSourceMatcherUnmarshaling(t *testing.T) {
 		shouldErrorOnLoad bool
 	}{
 		{
-			desc: "Garbage in garbage out",
+			desc: "Unmarshaling is strict",
 			yaml: `
 Blahblah: foo
 PackageRE: bar`,
 			shouldErrorOnLoad: false, // TODO true
+		},
+		{
+			desc: "Malformed YAML errors gracefully",
+			yaml: `
+PackageRE: "No ending quote`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Malformed regexp errors gracefully",
+			yaml: `
+PackageRE: "(?:NoEndingParen"`,
+			shouldErrorOnLoad: true,
 		},
 		{
 			desc: "Do not permit both Package and PackageRE",
@@ -299,19 +323,19 @@ func TestMatcherTypes(t *testing.T) {
 		},
 		{
 			desc:        "regexp matcher /foo/ matches foo",
-			matcher:     regexp.New("foo"),
+			matcher:     func() stringMatcher { r, _ := regexp.New("foo"); return r }(),
 			s:           "foo",
 			shouldMatch: true,
 		},
 		{
 			desc:        "regexp matcher /foo/ matches food",
-			matcher:     regexp.New("foo"),
+			matcher:     func() stringMatcher { r, _ := regexp.New("foo"); return r }(),
 			s:           "food",
 			shouldMatch: true,
 		},
 		{
 			desc:        "regexp matcher /foo/ does not match bar",
-			matcher:     regexp.New("foo"),
+			matcher:     func() stringMatcher { r, _ := regexp.New("foo"); return r }(),
 			s:           "bar",
 			shouldMatch: false,
 		},

--- a/internal/pkg/config/matcher_test.go
+++ b/internal/pkg/config/matcher_test.go
@@ -18,7 +18,6 @@ func TestFuncMatcher(t *testing.T) {
 			yaml: `
 Blahblah: foo
 PackageRE: bar`,
-			// TODO Discuss loss of strict loading
 			shouldErrorOnLoad: false, // TODO true
 		},
 		{
@@ -133,7 +132,6 @@ func TestSourceMatcher(t *testing.T) {
 			yaml: `
 Blahblah: foo
 PackageRE: bar`,
-			// TODO Discuss loss of strict loading
 			shouldErrorOnLoad: false, // TODO true
 		},
 		{

--- a/internal/pkg/config/matcher_test.go
+++ b/internal/pkg/config/matcher_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestFuncMatcher(t *testing.T) {
+	testCases := []struct {
+		desc, yaml        string
+		path, recv, name  string
+		shouldErrorOnLoad bool
+		shouldMatch       bool
+	}{
+		{
+			desc: "Garbage in garbage out",
+			yaml: `
+Blahblah: foo
+PackageRE: bar`,
+			// TODO Discuss loss of strict loading
+			shouldErrorOnLoad: false, // TODO true
+		},
+		{
+			desc: "Do not permit both Package and PackageRE",
+			yaml: `
+Package: foo
+PackageRE: bar`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Do not permit both Receiver and ReceiverRE",
+			yaml: `
+Receiver: foo
+ReceiverRE: bar`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Do not permit both Field and FieldRE",
+			yaml: `
+Method: foo
+MethodRE: bar`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Literal foo.bar should match foo.bar; no receiver arg",
+			yaml: `
+Package: foo
+Method: bar`,
+			path:        "foo",
+			recv:        "",
+			name:        "bar",
+			shouldMatch: true,
+		},
+		{
+			desc: "Literal foo.bar should match foo.(baz).bar; no receiver arg",
+			yaml: `
+Package: foo
+Method: bar`,
+			path:        "foo",
+			recv:        "baz",
+			name:        "bar",
+			shouldMatch: true,
+		},
+		{
+			desc: "Literal foo.bar should NOT match foodstuff.bar; no receiver arg",
+			yaml: `
+Package: foo
+Method: bar`,
+			path:        "foodstuff",
+			recv:        "",
+			name:        "bar",
+			shouldMatch: false,
+		},
+		{
+			desc: "Mixed regexp and literal matchers are permitted - positive case",
+			yaml: `
+PackageRE: foo
+Receiver: baz
+Method: bar`,
+			path:        "foodstuff",
+			recv:        "baz",
+			name:        "bar",
+			shouldMatch: true,
+		},
+		{
+			desc: "Mixed regexp and literal matchers are permitted - negative case",
+			yaml: `
+PackageRE: foo
+Receiver: baz
+Method: bar`,
+			path:        "foodstuff",
+			recv:        "bazinga",
+			name:        "bar",
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fm := funcMatcher{}
+			err := yaml.UnmarshalStrict([]byte(tc.yaml), &fm)
+
+			if tc.shouldErrorOnLoad {
+				if err == nil {
+					t.Errorf("Expected yaml to fail on load, got err = nil")
+				}
+				return
+			}
+
+			if !tc.shouldErrorOnLoad && err != nil {
+				t.Error(err)
+				return
+			}
+
+			if tc.shouldMatch != fm.MatchFunction(tc.path, tc.recv, tc.name) {
+				t.Errorf("MatchFunction(%q, %q, %q) = %v; got %v", tc.path, tc.recv, tc.name, tc.shouldMatch, !tc.shouldMatch)
+			}
+		})
+	}
+}
+
+func TestSourceMatcher(t *testing.T) {
+	testCases := []struct {
+		desc, yaml           string
+		path, typ, fieldName string
+		shouldErrorOnLoad    bool
+		shouldMatchType      bool
+		shouldMatchField     bool
+	}{
+		{
+			desc: "Garbage in garbage out",
+			yaml: `
+Blahblah: foo
+PackageRE: bar`,
+			// TODO Discuss loss of strict loading
+			shouldErrorOnLoad: false, // TODO true
+		},
+		{
+			desc: "Do not permit both Package and PackageRE",
+			yaml: `
+Package: foo
+PackageRE: bar`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Do not permit both Type and TypeRE",
+			yaml: `
+Type: foo
+TypeRE: bar`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Do not permit both Field and FieldRE",
+			yaml: `
+Field: foo
+FieldRE: bar`,
+			shouldErrorOnLoad: true,
+		},
+		{
+			desc: "Literal foo.bar (no field args) should match foo.bar and foo.bar.baz",
+			yaml: `
+Package: foo
+Type: bar`,
+			path:             "foo",
+			typ:              "bar",
+			fieldName:        "baz",
+			shouldMatchType:  true,
+			shouldMatchField: true,
+		},
+		{
+			desc: "Literal foo.bar (no field args) should NOT match foodstuff.bar or foodstuff.bar.baz",
+			yaml: `
+Package: foo
+Type: bar`,
+			path:             "foodstuff",
+			typ:              "bar",
+			fieldName:        "baz",
+			shouldMatchType:  false,
+			shouldMatchField: false,
+		},
+		{
+			desc: "Regexp foo.bar (no field args) should match foodstuff.bar and foodstuff.bar.baz",
+			yaml: `
+PackageRE: foo
+TypeRE: bar`,
+			path:             "foodstuff",
+			typ:              "bar",
+			fieldName:        "baz",
+			shouldMatchType:  true,
+			shouldMatchField: true,
+		},
+		{
+			desc: "Mixed regexp and literal matchers are permitted",
+			yaml: `
+PackageRE: foo
+Type: bar
+Field: baz`,
+			path:             "foodstuff",
+			typ:              "bar",
+			fieldName:        "baz",
+			shouldMatchType:  true,
+			shouldMatchField: true,
+		},
+		{
+			desc: "Literal foo.bar.qux should MatchType foo.bar but not MatchField foo.bar.baz",
+			yaml: `
+PackageRE: foo
+Type: bar
+Field: qux`,
+			path:             "foodstuff",
+			typ:              "bar",
+			fieldName:        "baz",
+			shouldMatchType:  true,
+			shouldMatchField: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sm := sourceMatcher{}
+			err := yaml.UnmarshalStrict([]byte(tc.yaml), &sm)
+
+			if tc.shouldErrorOnLoad {
+				if err == nil {
+					t.Errorf("Expected yaml to fail on load, got err = nil")
+				}
+				return
+			}
+
+			if !tc.shouldErrorOnLoad && err != nil {
+				t.Error(err)
+				return
+			}
+
+			if tc.shouldMatchType != sm.MatchType(tc.path, tc.typ) {
+				t.Errorf("MatchType(%q, %q) = %v; got %v", tc.path, tc.typ, tc.shouldMatchType, !tc.shouldMatchType)
+			}
+			if tc.shouldMatchField != sm.MatchField(tc.path, tc.typ, tc.fieldName) {
+				t.Errorf("MatchField(%q, %q, %q) = %v; got %v", tc.path, tc.typ, tc.fieldName, tc.shouldMatchType, !tc.shouldMatchType)
+			}
+		})
+	}
+}

--- a/internal/pkg/config/regexp/regexp.go
+++ b/internal/pkg/config/regexp/regexp.go
@@ -28,7 +28,7 @@ type Regexp struct {
 
 // MatchString delegates matching to the regex package.
 func (mr *Regexp) MatchString(s string) bool {
-	return mr == nil || mr.r == nil || mr.r.MatchString(s)
+	return mr.r == nil || mr.r.MatchString(s)
 }
 
 // UnmarshalJSON implementation of json.UnmarshalJSON interface.

--- a/internal/pkg/config/regexp/regexp.go
+++ b/internal/pkg/config/regexp/regexp.go
@@ -28,7 +28,7 @@ type Regexp struct {
 
 // MatchString delegates matching to the regex package.
 func (mr *Regexp) MatchString(s string) bool {
-	return mr.r == nil || mr.r.MatchString(s)
+	return mr == nil || mr.r == nil || mr.r.MatchString(s)
 }
 
 // UnmarshalJSON implementation of json.UnmarshalJSON interface.

--- a/internal/pkg/config/regexp/regexp.go
+++ b/internal/pkg/config/regexp/regexp.go
@@ -26,8 +26,9 @@ type Regexp struct {
 	r *regexp.Regexp
 }
 
-func New(s string) *Regexp {
-	return &Regexp{r: regexp.MustCompile(s)}
+func New(s string) (*Regexp, error) {
+	r, err := regexp.Compile(s)
+	return &Regexp{r: r}, err
 }
 
 // MatchString delegates matching to the regex package.

--- a/internal/pkg/config/regexp/regexp.go
+++ b/internal/pkg/config/regexp/regexp.go
@@ -26,6 +26,10 @@ type Regexp struct {
 	r *regexp.Regexp
 }
 
+func New(s string) *Regexp {
+	return &Regexp{r: regexp.MustCompile(s)}
+}
+
 // MatchString delegates matching to the regex package.
 func (mr *Regexp) MatchString(s string) bool {
 	return mr.r == nil || mr.r.MatchString(s)


### PR DESCRIPTION
* Expand testing of matchers, now that the interface is reduced to basic types.
* Update docs.
* Unspecified elements continue to match vacuously.

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [x] Appropriate changes to README are included in PR