### PR TITLE
Add nil-check for safety on interface methods.

### DIFF
--- a/internal/pkg/fieldpropagator/analyzer.go
+++ b/internal/pkg/fieldpropagator/analyzer.go
@@ -74,8 +74,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 		methods := ssaProg.MethodSets.MethodSet(ssaType.Type())
 		for i := 0; i < methods.Len(); i++ {
-			meth := ssaProg.MethodValue(methods.At(i))
-			analyzeBlocks(pass, conf, taggedFields, meth)
+			if meth := ssaProg.MethodValue(methods.At(i)); meth != nil {
+				analyzeBlocks(pass, conf, taggedFields, meth)
+			}
 		}
 	}
 


### PR DESCRIPTION
`master` is currently dereferencing a `nil` when running against Kubernetes.  This was introduced by #164, either by awkwardly merging with other commits or, more likely, I failed to re-verify a Kubernetes run after responding to requested changes.

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [n/a] Appropriate changes to README are included in PR