### PR TITLE
Add tests for range to not propagate to non-source types.

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/arrays.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/arrays.go
@@ -43,7 +43,9 @@ func TestArrayRemainsTaintedWhenSourceIsOverwritten(s core.Source) {
 
 func TestRangeOverArray() {
 	sources := [1]core.Source{core.Source{Data: "password1234"}}
-	for _, s := range sources {
+	for i, s := range sources {
 		core.Sink(s) // want "a source has reached a sink"
+		// TODO want no diagnostic reported for string value
+		core.Sink(i) // want "a source has reached a sink"
 	}
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/maps.go
@@ -71,9 +71,20 @@ func TestMapUpdateWithTaintedKeyDoesNotTaintTheValue(key core.Source, value stri
 	core.Sink(value) // want "a source has reached a sink"
 }
 
-func TestRangeOverMap() {
+func TestRangeOverMapWithSourceAsValue() {
 	m := map[string]core.Source{"secret": core.Source{Data: "password1234"}}
-	for _, s := range m {
+	for k, s := range m {
 		core.Sink(s) // want "a source has reached a sink"
+		// TODO want no diagnostic reported for string key
+		core.Sink(k) // want "a source has reached a sink"
+	}
+}
+
+func TestRangeOverMapWithSourceAsKey() {
+	m := map[core.Source]string{core.Source{Data: "password1234"}: "don't sink me"}
+	for src, str := range m {
+		core.Sink(src) // want "a source has reached a sink"
+		// TODO want no diagnostic reported for string value
+		core.Sink(str) // want "a source has reached a sink"
 	}
 }

--- a/internal/pkg/levee/testdata/src/example.com/tests/collections/slices.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/collections/slices.go
@@ -29,13 +29,17 @@ func TestSlices(s core.Source) {
 
 func TestRangeOverSlice() {
 	sources := []core.Source{core.Source{Data: "password1234"}}
-	for _, s := range sources {
+	for i, s := range sources {
 		core.Sink(s) // want "a source has reached a sink"
+		// TODO want no diagnostic reported for string value
+		core.Sink(i) // want "a source has reached a sink"
 	}
 }
 
 func TestRangeOverInterfaceSlice() {
-	for _, s := range []interface{}{core.Source{Data: "password1235"}} {
+	for i, s := range []interface{}{core.Source{Data: "password1235"}} {
 		core.Sink(s) // want "a source has reached a sink"
+		// TODO want no diagnostic reported for string value
+		core.Sink(i) // want "a source has reached a sink"
 	}
 }


### PR DESCRIPTION
Running recently against K8s exposed propagation to keys when sources were only in maps.

These tests should be addressed in or after #178.