### PR TITLE
Remove dead Source.RefersTo method

### DIFF
--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -255,10 +255,6 @@ func (s *Source) compress() []ssa.Node {
 	return compressed
 }
 
-func (s *Source) RefersTo(n ssa.Node) bool {
-	return s.HasPathTo(n)
-}
-
 // HasPathTo returns true when a Node is part of declaration-use graph.
 func (s *Source) HasPathTo(n ssa.Node) bool {
 	return s.marked[n]


### PR DESCRIPTION
I meant to include this in #178, but I forgot to push before merging. 

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR