### PR TITLE
Only traverse to store addr

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/store/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/store/tests.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"example.com/core"
+)
+
+func TestStoringToTaintedAddrDoesNotTaintStoredValue() {
+	myChan := make(chan string)
+	s := core.Source{Data: "foo"}
+	recv := <-myChan
+	s.Data = recv
+	core.Sink(recv)
+	core.Sink(myChan)
+}

--- a/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
@@ -51,7 +51,7 @@ func TestPanicTypeAssertSource(i interface{}) {
 	s := i.(core.Source)
 	_ = s
 	// The dominating type assertion would panic if i were not a source type.
-	core.Sink(i) // want "a source has reached a sink"
+	core.Sink(i) // TODO want "a source has reached a sink"
 }
 
 func TestPanicTypeAssertInnocuous(i interface{}) {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -199,6 +199,10 @@ func (s *Source) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, last
 		s.visitReferrers(n, maxInstrReached, lastBlockVisited)
 		s.dfs(t.X.(ssa.Node), maxInstrReached, lastBlockVisited, false)
 
+	// Only the Addr (the Value that is being written to) should be visited.
+	case *ssa.Store:
+		s.dfs(t.Addr.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+
 	// Only the Map itself can be tainted by an Update.
 	// The Key can't be tainted.
 	// The Value can propagate taint to the Map, but not receive it.
@@ -222,7 +226,7 @@ func (s *Source) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, last
 		s.visitReferrers(n, maxInstrReached, lastBlockVisited)
 
 	// These nodes don't have referrers; they are Instructions, not Values.
-	case *ssa.Go, *ssa.Store:
+	case *ssa.Go:
 		s.visitOperands(n, maxInstrReached, lastBlockVisited)
 
 	// These nodes are both Instructions and Values, and currently have no special restrictions.


### PR DESCRIPTION
Investigating a new test case suggested by @PurelyApplied led me to find a related case where propagating to the `Value` in `Store` causes a spurious report to be produced:

```go

func TestStoringToTaintedAddrDoesNotTaintStoredValue() {
	myChan := make(chan string)
	s := core.Source{Data: "foo"}
	recv := <-myChan
	s.Data = recv
	core.Sink(recv)
	core.Sink(myChan)
}
```

On master, `core.Sink(recv)` in the above example yields a spurious report. (`core.Sink(myChan)` is there for additional certainty.)

Not propagating to the `Value` seems like the right thing to do, since it makes no sense. However, it does mean that we no longer handle this case:

```go
func TestPanicTypeAssertSource(i interface{}) {
	s := i.(core.Source)
	_ = s
	// The dominating type assertion would panic if i were not a source type.
	core.Sink(i) // TODO want "a source has reached a sink"
}
```

I think this is an acceptable regression, since this test was passing because we were doing a weird propagation, not because we were properly handling the semantics of the code.

Related issue: #188.

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR