### PR TITLE
Add failing MakeInterface test case

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/makeinterface/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/makeinterface/tests.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletethis
+
+import (
+	"example.com/core"
+)
+
+func TestTaintingInterfaceValueDoesNotTaintContainedValue(s *core.Source, str string) {
+	var x interface{} = str
+	colocate(s, x)
+	// TODO: no report should be produced below
+	core.Sink(str) // want "a source has reached a sink"
+}
+
+func colocate(s *core.Source, x interface{}) {}


### PR DESCRIPTION
This PR is a part of #188.

This PR adds a failing test showing incorrect propagation for `MakeInterface` instructions in some cases:
```go
func TestTaintingInterfaceValueDoesNotTaintContainedValue(s *core.Source, str string) {
	var x interface{} = str
	colocate(s, x)
	// TODO: no report should be produced below
	core.Sink(str) // want "a source has reached a sink"
}

func colocate(s *core.Source, x interface{}) {}
```

The incorrect behavior here is similar to what is happening with `Store` instructions (see #199): we are propagating to the `Value` that is being made into an interface. In the above test case, that does not make sense: `str` cannot become tainted as a result of the `interface{}` value holding `str` being tainted.

A small tweak (changing `str` to be of `*string` type) to the above test case makes it less clear what the correct behavior would be:
```go
func TestTaintingInterfaceValueDoesNotTaintContainedValue(s *core.Source, str *string) {
	var x interface{} = str
	colocate(s, x)
	core.Sink(str) // want "a source has reached a sink" ?
}
```

In this case, `colocate` could conceivably type assert the pointer out of the interface and change the string, so this code may not be safe. One mitigation against spurious reports like the one in this test case would therefore be to only propagate to the `Value` in a `MakeInterface` if it has a pointer-like type (like we are considering for calls in #185). We already have a case covering this behavior: 

```go
func TestTaintIsPropagatedToColocatedPointerArgumentsThroughEface(s core.Source, ip *core.Innocuous) {
	taintColocatedEface(s, ip)
	core.Sink(ip) // want "a source has reached a sink"
}
```

In the above case, the `MakeInterface` instruction is implicit. It is added by the ssa builder because `taintColocatedEface` takes `interface{}` type arguments.

- [x] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR