### PR TITLE
Move things that are relevant to developers to their own file

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,44 @@
+# Developing Go Flow Levee
+
+## Debugging
+
+The main analyzer depends heavily on the SSA package. Being able to read the SSA code and visualize its graph can be very useful for debugging. In order to generate the SSA code and DOT (graphviz) source for every function in a test, run `go test <package> -debug`. Results are written to the `output` directory. You can generate a PDF from the DOT source using `dot -Tpdf <file> -o "$(basename <file> .dot).pdf"`.
+
+Currently, debugging is only supported for the `levee` analyzer. In order to add support for debugging in a new test, first add a debugging flag:
+```go
+var debugging bool = flag.Bool("debug", false, "run the debug analyzer")
+```
+Then add `debug.Analyzer` as a dependency of the analyzer being tested:
+```go
+if *debugging {
+	Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
+}
+```
+
+In the `dot` output:
+* A **red** edge points to a **Referrer** of an `ssa.Node`
+* An **orange** edge points to an **Operand** of an `ssa.Node`
+* **Rectangle**-shaped nodes represent `ssa.Node`s that are both `ssa.Instruction`s and `ssa.Value`s
+* **Diamond**-shaped nodes represent `ssa.Node`s that are only `ssa.Instruction`s
+* **Ellipse**-shaped nodes represent `ssa.Node`s that are either only `ssa.Value`s, or are `ssa.Member`s.
+
+The function's control-flow graph (CFG) is also produced and written in a file named `<function-name>-cfg.dot`.
+
+## Source Code Headers
+
+Every file containing source code or data (e.g., YAML configuration files) must include
+the Apache header:
+
+    Copyright 2020 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Debugging
 
-The main analyzer depends heavily on the SSA package. Being able to read the SSA code and visualize its graph can be very useful for debugging. In order to generate the SSA code and DOT (graphviz) source for every function in a test, run `go test <package> -debug`. Results are written to the `output` directory. You can generate a PDF from the DOT source using `dot -Tpdf <file> -o "$(basename <file> .dot).pdf"`.
+The main analyzer depends heavily on the [golang.org/x/tools/ssa](https://pkg.go.dev/golang.org/x/tools/ssa) package. Being able to read the SSA code and visualize its graph can be very useful for debugging. In order to generate the SSA code and DOT ([graphviz](https://graphviz.org/)) source for every function in a test, run `go test <package> -debug`. Results are written to the `output` directory. You can generate a PDF from the DOT source using `dot -Tpdf <file> -o "$(basename <file> .dot).pdf"`.
 
 Currently, debugging is only supported for the `levee` analyzer. In order to add support for debugging in a new test, first add a debugging flag:
 ```go

--- a/README.md
+++ b/README.md
@@ -42,56 +42,13 @@ Since taint propagation is often used as a security safeguard, we care more deep
 
 For general bug reports (e.g. crashes), please open an issue [here](https://github.com/google/go-flow-levee/issues/new?template=bug_report.md).
 
-### Debugging
-
-The main analyzer depends heavily on the SSA package. Being able to read the SSA code and visualize its graph can be very useful for debugging. In order to generate the SSA code and DOT (graphviz) source for every function in a test, run `go test levee_test.go -debug`. Results are written to the `output` directory. You can generate a PDF from the DOT source using `dot -Tpdf <file> -o "$(basename <file> .dot).pdf"`.
-
-Currently, debugging is only supported for `levee_test.go`. In order to add support for debugging in a new test, first add a debugging flag:
-```go
-var debugging bool = flag.Bool("debug", false, "run the debug analyzer")
-```
-Then add `debug.Analyzer` as a dependency of the analyzer being tested:
-```go
-if *debugging {
-	Analyzer.Requires = append(Analyzer.Requires, debug.Analyzer)
-}
-```
-
-In the `dot` output:
-* A **red** edge points to a **Referrer** of an `ssa.Node`
-* An **orange** edges points to an **Operand** of an `ssa.Node`
-* **Rectangle**-shaped nodes represent `ssa.Node`s that are both `ssa.Instruction`s and `ssa.Value`s
-* **Diamond**-shaped nodes represent `ssa.Node`s that are only `ssa.Instruction`s
-* **Ellipse**-shaped nodes represent `ssa.Node`s that are either only `ssa.Value`s, or are `ssa.Member`s.
-
-The function's control-flow graph (CFG) is also produced and written in a file named `<function-name>-cfg.dot`.
-
-## Source Code Headers
-
-Every file containing source code must include copyright and license
-information. This includes any JS/CSS files that you might be serving out to
-browsers. (This is to help well-intentioned people avoid accidental copying that
-doesn't comply with the license.)
-
-Apache header:
-
-    Copyright 2020 Google LLC
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        https://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+## Developing
+
+See [DEVELOPING.md](DEVELOPING.md) for details.
 
 ## Disclaimer
 


### PR DESCRIPTION
This is in the interest of separating things that are relevant for users from things that are relevant for developers, in an effort to make it easier for both to find what they are looking for. This will become more important as more information is added to each doc.

- (N/A) [ ] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [x] Appropriate changes to README are included in PR