### PR TITLE
Add validation to config fields.

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -33,16 +33,13 @@ var (
 	// FlagSet should be used by analyzers to reuse -config flag.
 	FlagSet                    flag.FlagSet
 	configFile                 string
-	validFuncMatcherFields     []string
-	validSourceMatcherFields   []string
-	validFieldTagMatcherFields []string
+	validFuncMatcherFields     []string = []string{"package", "packagere", "receiver", "receiverre", "method", "methodre"}
+	validSourceMatcherFields   []string = []string{"package", "packagere", "type", "typere", "field", "fieldre"}
+	validFieldTagMatcherFields []string = []string{"key", "val", "value"}
 )
 
 func init() {
 	FlagSet.StringVar(&configFile, "config", "config.yaml", "path to analysis configuration file")
-	validFuncMatcherFields = []string{"package", "packagere", "receiver", "receiverre", "method", "methodre"}
-	validSourceMatcherFields = []string{"package", "packagere", "type", "typere", "field", "fieldre"}
-	validFieldTagMatcherFields = []string{"key", "val", "value"}
 }
 
 // Config contains matchers and analysis scope information.

--- a/internal/pkg/config/matcher_test.go
+++ b/internal/pkg/config/matcher_test.go
@@ -67,7 +67,7 @@ MethodRE: bar`,
 			err := yaml.UnmarshalStrict([]byte(tc.yaml), &fm)
 
 			if err == nil {
-				t.Error("want error, but got err = nil")
+				t.Error("got err = nil, want error")
 			}
 		})
 	}
@@ -147,50 +147,43 @@ Method: bar`,
 	}
 }
 
-func TestSourceMatcherUnmarshaling(t *testing.T) {
+func TestSourceMatcherUnmarshalingErrorCases(t *testing.T) {
 	testCases := []struct {
-		desc, yaml        string
-		shouldErrorOnLoad bool
+		desc, yaml string
 	}{
 		{
 			desc: "Unmarshaling is strict",
 			yaml: `
 Blahblah: foo
 PackageRE: bar`,
-			shouldErrorOnLoad: true,
 		},
 		{
 			desc: "Malformed YAML errors gracefully",
 			yaml: `
 PackageRE: "No ending quote`,
-			shouldErrorOnLoad: true,
 		},
 		{
 			desc: "Malformed regexp errors gracefully",
 			yaml: `
 PackageRE: "(?:NoEndingParen"`,
-			shouldErrorOnLoad: true,
 		},
 		{
 			desc: "Do not permit both Package and PackageRE",
 			yaml: `
 Package: foo
 PackageRE: bar`,
-			shouldErrorOnLoad: true,
 		},
 		{
 			desc: "Do not permit both Type and TypeRE",
 			yaml: `
 Type: foo
 TypeRE: bar`,
-			shouldErrorOnLoad: true,
 		},
 		{
 			desc: "Do not permit both Field and FieldRE",
 			yaml: `
 Field: foo
 FieldRE: bar`,
-			shouldErrorOnLoad: true,
 		},
 	}
 
@@ -199,8 +192,8 @@ FieldRE: bar`,
 			sm := sourceMatcher{}
 			err := yaml.UnmarshalStrict([]byte(tc.yaml), &sm)
 
-			if (err != nil) != tc.shouldErrorOnLoad {
-				t.Errorf("got err = %v, want err = %v", err, tc.shouldErrorOnLoad)
+			if err == nil {
+				t.Errorf("got err = nil, want err != nil")
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #206 

Add validation for config yaml fields.
Notice that we have both upper case (e.g. "Key") and lower case (e.g. "key") in our unit tests and sample files. The validation will allow both.

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- [ ] Appropriate changes to README are included in PR