### PR TITLE
Add instructions for running on a large codebase

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@ Fixes #<issue_number_goes_here>
 > It's a good idea to open an issue first for discussion.
 
 - [ ] Tests pass
-- [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
+- [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
 - [ ] Appropriate changes to README are included in PR

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,30 @@
 # Developing Go Flow Levee
 
+## Testing Your Changes Against a Large Codebase
+
+When creating a pull request, you must certify that your changes are safe by running them on a large codebase such as [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes). This is not intended as a replacement for proper automated testing. Running without error on a large codebase provides an additional level of confidence, since a large codebase is likely to contain edge cases that you may not have considered. Indeed, such edge cases have caused failures in the past ([#74](https://github.com/google/go-flow-levee/pull/74), [#143](https://github.com/google/go-flow-levee/pull/143)).
+
+Here's an example script showing how you can test your changes against [Kubernetes](https://github.com/kubernetes/kubernetes):
+
+```bash
+#!/bin/bash
+
+set -eux
+
+# set these to appropriate values for your setup
+# GO_FLOW_LEVEE_PATH=path to the root of the go-flow-levee repository on your machine
+# K8S_PATH="$GOPATH"/src/k8s.io/kubernetes
+
+cd "$GO_FLOW_LEVEE_PATH"/cmd/levee
+go install
+
+cd "$K8S_PATH"
+git checkout master
+git pull
+CFG_PATH="$(realpath ./hack/testdata/levee/levee-config.yaml)"
+make vet WHAT="-vettool=$(which levee) -config=$CFG_PATH"
+```
+
 ## Recommended Reading
 
 Having some knowledge of the following packages is helpful when developing Go Flow Levee:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Testing Your Changes Against a Large Codebase
 
-When creating a pull request, you must certify that your changes are safe by running them on a large codebase such as [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes). This is not intended as a replacement for proper automated testing. Running without error on a large codebase provides an additional level of confidence, since a large codebase is likely to contain edge cases that you may not have considered. Indeed, such edge cases have caused failures in the past ([#74](https://github.com/google/go-flow-levee/pull/74), [#143](https://github.com/google/go-flow-levee/pull/143)).
+When creating a pull request, you must verify that your changes are safe by running them on a large codebase such as [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes). This is not intended as a replacement for proper automated testing. Running without error on a large codebase provides an additional level of confidence, since a large codebase is likely to contain edge cases that you may not have considered. Indeed, such edge cases have caused failures in the past ([#74](https://github.com/google/go-flow-levee/pull/74), [#143](https://github.com/google/go-flow-levee/pull/143)).
 
 Here's an example script showing how you can test your changes against [Kubernetes](https://github.com/kubernetes/kubernetes):
 


### PR DESCRIPTION
Up to now, we have not had any specific instructions for how to run the analyzer on a large codebase, despite the fact that this is one of our criteria for accepting PR's.

This PR adds instructions aimed at developers who want to perform this check. This should help make contributing more accessible.

- (N/A) [ ] Tests pass
- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out.
- (N/A) [ ] Appropriate changes to README are included in PR