### PR TITLE
Remove all instances where we skip over recover blocks.

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -56,10 +56,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// Only examine functions that have sources
 	for fn, sources := range sourcesMap {
 		for _, b := range fn.Blocks {
-			if b == fn.Recover {
-				continue // skipping Recover since it does not have instructions, rather a single block.
-			}
-
 			for _, instr := range b.Instrs {
 				v, ok := instr.(*ssa.Call)
 				if !ok {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -115,10 +115,6 @@ func sourcesFromClosure(fn *ssa.Function, conf Classifier, taggedFields fieldtag
 func sourcesFromBlocks(fn *ssa.Function, conf Classifier, taggedFields fieldtags.ResultType) []*Source {
 	var sources []*Source
 	for _, b := range fn.Blocks {
-		if b == fn.Recover {
-			continue
-		}
-
 		for _, instr := range b.Instrs {
 			// This type switch is used to catch instructions that could produce sources.
 			// All instructions that do not match one of the cases will hit the "default"


### PR DESCRIPTION
We don't need special case handling of a recover blocks. Some details about recover blocks from https://godoc.org/golang.org/x/tools/go/ssa below:
```
Recover is an optional second entry point to which control resumes after a recovered panic. The Recover block 
may contain only a return statement, preceded by a load of the function's named return parameters, if any.
``` 
- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [ ] Appropriate changes to README are included in PR
