### PR TITLE
Identify sources from panicky ssa.TypeAssert

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200416214402-fc959738d646 h1:7CEkhBsBejkW845gR1AmglqMfc1yGzn42FBmtM4jxyM=
 golang.org/x/tools v0.0.0-20200416214402-fc959738d646/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20201211185031-d93e913c1a58 h1:1Bs6RVeBFtLZ8Yi1Hk07DiOqzvwLD/4hln4iahvFlag=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200416214402-fc959738d646 h1:7CEkhBsBejkW845gR1AmglqMfc1yGzn42FBmtM4jxyM=
 golang.org/x/tools v0.0.0-20200416214402-fc959738d646/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20201211185031-d93e913c1a58 h1:1Bs6RVeBFtLZ8Yi1Hk07DiOqzvwLD/4hln4iahvFlag=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typeassert/assertion_inference_tests.go
@@ -51,7 +51,7 @@ func TestPanicTypeAssertSource(i interface{}) {
 	s := i.(core.Source)
 	_ = s
 	// The dominating type assertion would panic if i were not a source type.
-	core.Sink(i) // TODO(210) want "a source has reached a sink"
+	core.Sink(i) // want "a source has reached a sink"
 }
 
 func TestPanicTypeAssertInnocuous(i interface{}) {

--- a/internal/pkg/levee/testdata/src/example.com/tests/typeassert/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/typeassert/tests.go
@@ -30,7 +30,7 @@ func TestSourcePointerAssertedFromTaintedEface(s *core.Source) {
 
 func TestSourcePointerAssertedFromParameterEface(e interface{}) {
 	s := e.(*core.Source)
-	core.Sink(s) // TODO(#190) want "a source has reached a sink"
+	core.Sink(s) // want "a source has reached a sink"
 }
 
 func TestSourcePointerAssertedFromParameterEfaceCommaOk(e interface{}) {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -134,7 +134,9 @@ func sourcesFromBlocks(fn *ssa.Function, conf Classifier, taggedFields fieldtags
 				if isProducedBySanitizer(v.(ssa.Value), conf) {
 					continue
 				}
-
+			// A panicky type assert like s := e.(*core.Source) does not result in ssa.Extract
+			// so we need to create a source if the type assert is panicky i.e. CommaOk is false
+			// and the type being asserted is a source type.
 			case *ssa.TypeAssert:
 				if !v.CommaOk && IsSourceType(conf, taggedFields, v.AssertedType) {
 					sources = append(sources, New(v))

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -134,6 +134,10 @@ func sourcesFromBlocks(fn *ssa.Function, conf Classifier, taggedFields fieldtags
 				if isProducedBySanitizer(v.(ssa.Value), conf) {
 					continue
 				}
+			case *ssa.TypeAssert:
+				if !v.CommaOk && IsSourceType(conf, taggedFields, v.AssertedType) {
+					sources = append(sources, New(v))
+				}
 
 			// An Extract is used to obtain a value from an instruction that returns multiple values.
 			// If the Extract is used to get a Pointer, create a Source, otherwise the Source won't

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -134,6 +134,7 @@ func sourcesFromBlocks(fn *ssa.Function, conf Classifier, taggedFields fieldtags
 				if isProducedBySanitizer(v.(ssa.Value), conf) {
 					continue
 				}
+
 			// A panicky type assert like s := e.(*core.Source) does not result in ssa.Extract
 			// so we need to create a source if the type assert is panicky i.e. CommaOk is false
 			// and the type being asserted is a source type.

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -134,6 +134,7 @@ func sourcesFromBlocks(fn *ssa.Function, conf Classifier, taggedFields fieldtags
 				if isProducedBySanitizer(v.(ssa.Value), conf) {
 					continue
 				}
+
 			case *ssa.TypeAssert:
 				if !v.CommaOk && IsSourceType(conf, taggedFields, v.AssertedType) {
 					sources = append(sources, New(v))


### PR DESCRIPTION
If a ssa.TypeAssert instruction does not have CommaOk and the AssertedType is a source then, create a Source.
Fixes #190 

**Why is this change needed?**

Today go-flow-levee correctly identifies that a source has reached a sink for the following code:
```go
func TestSourcePointerAssertedFromParameterEfaceCommaOk(e interface{}) {
	s,ok := e.(*core.Source)
        core.Sink(s) 
}
```
The SSA for the code above is:
```go
func TestSourcePointerAssertedFromParameterEfaceCommaOk(e interface{})
0: entry
	 0(*ssa.TypeAssert     ): t0 = typeassert,ok e.(*example.com/core.Source)
	 1(*ssa.Extract        ): t1 = extract t0 #0
	 2(*ssa.Extract        ): t2 = extract t0 #1
	 3(*ssa.Alloc          ): t3 = new [1]interface{} (varargs)
	 4(*ssa.IndexAddr      ): t4 = &t3[0:int]
	 5(*ssa.MakeInterface  ): t5 = make interface{} <- *example.com/core.Source (t1)
	 6(*ssa.Store          ): *t4 = t5
	 7(*ssa.Slice          ): t6 = slice t3[:]
	 8(*ssa.Call           ): t7 = example.com/core.Sink(t6...)
	 9(*ssa.Alloc          ): t8 = new [1]interface{} (varargs)
	10(*ssa.IndexAddr      ): t9 = &t8[0:int]
	11(*ssa.MakeInterface  ): t10 = make interface{} <- bool (t2)
	12(*ssa.Store          ): *t9 = t10
	13(*ssa.Slice          ): t11 = slice t8[:]
	14(*ssa.Call           ): t12 = example.com/core.Sink(t11...)
	15(*ssa.Return         ): return
```
Note that the ssa.TypeAssert is followed by the ssa.Extract. This works because we handle ssa.Extract correctly.
 
However, go-flow-levee does not report that a source has reached a sink for the function below:
```go
func TestSourcePointerAssertedFromParameterEface(e interface{}) {
	s := e.(*core.Source)
        core.Sink(s) 
}
```
The SSA for this as follow:
```go
func TestSourcePointerAssertedFromParameterEface(e interface{})
0: entry
	0(*ssa.TypeAssert     ): t0 = typeassert e.(*example.com/core.Source)
	1(*ssa.Alloc          ): t1 = new [1]interface{} (varargs)
	2(*ssa.IndexAddr      ): t2 = &t1[0:int]
	3(*ssa.MakeInterface  ): t3 = make interface{} <- *example.com/core.Source (t0)
	4(*ssa.Store          ): *t2 = t3
	5(*ssa.Slice          ): t4 = slice t1[:]
	6(*ssa.Call           ): t5 = example.com/core.Sink(t4...)
	7(*ssa.Return         ): return
```
Since we were not checking if the type assertion worked as in `s, ok := e.(*core.Source)` case and just panic there is no ssa.Extract instruction, we need to handle the case ssa.TypeAssert with ssa.TypeAssert.CommaOk being false case explicitly and create a source if ssa.TypeAssert.AssertedType is a source type.

Thanks to @mlevesquedion for helping me understand this problem and its solution.

- [x] Tests pass
- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [ ] Appropriate changes to README are included in PR
