### PR TITLE
Remove 'Tests pass' checkbox from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,5 @@ Fixes #<issue_number_goes_here>
 
 > It's a good idea to open an issue first for discussion.
 
-- [ ] Tests pass
 - [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
 - [ ] Appropriate changes to README are included in PR


### PR DESCRIPTION
Verifying that the tests are passing is the CI's job, it does not matter whether the box is checked or not.