### PR TITLE
Freshen levee package docs

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -53,7 +53,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			propagations[s.Node] = propagation.Dfs(s.Node, conf, taggedFields)
 		}
 	}
-	// Only examine functions that have sources
+
 	for fn, sources := range sourcesMap {
 		for _, b := range fn.Blocks {
 			if b == fn.Recover {

--- a/internal/pkg/levee/propagation/propagation.go
+++ b/internal/pkg/levee/propagation/propagation.go
@@ -57,6 +57,16 @@ func Dfs(n ssa.Node, conf source.Classifier, taggedFields fieldtags.ResultType) 
 	return record
 }
 
+// dfs performs a depth-first search of the graph formed by SSA Referrers and
+// Operands relationships. Along the way, visited nodes are marked and stored
+// in a slice which captures the visitation order. Sanitizers are also recorded.
+// maxInstrReached and lastBlockVisited are used to give the traversal some
+// degree of flow sensitivity. Specifically:
+// - maxInstrReached records the highest index of an instruction visited
+//   in each block. This is used to avoid visiting past instructions, e.g.
+//   a call to a sink where the argument was tainted after the call happened.
+// - lastBlockVisited is used to determine whether the next instruction to visit
+//   can be reached from the current instruction.
 func (prop *Propagation) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, isReferrer bool) {
 	if prop.shouldNotVisit(n, maxInstrReached, lastBlockVisited, isReferrer) {
 		return

--- a/internal/pkg/levee/propagation/propagation.go
+++ b/internal/pkg/levee/propagation/propagation.go
@@ -41,7 +41,7 @@ type Propagation struct {
 }
 
 // Dfs performs a depth-first search of the graph formed by SSA Referrers and
-// Operands relationships.
+// Operands relationships, beginning at the given root node.
 func Dfs(n ssa.Node, conf source.Classifier, taggedFields fieldtags.ResultType) Propagation {
 	record := Propagation{
 		root:         n,


### PR DESCRIPTION
This PR aims to improve the documentation for the `levee` and `propagation` packages. Specifically, it adds a few documentation comments and removes/rectifies a few incorrect pieces of documentation.