### PR TITLE
Use already-define callee variable.

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -67,7 +67,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				case fieldPropagators.IsFieldPropagator(v):
 					propagations[v] = propagation.Dfs(v, conf, taggedFields)
 					sources = append(sources, source.New(v))
-				case callee != nil && conf.IsSink(utils.DecomposeFunction(v.Call.StaticCallee())):
+				case callee != nil && conf.IsSink(utils.DecomposeFunction(callee)):
 					for _, s := range sources {
 						prop := propagations[s.Node]
 						if prop.HasPathTo(instr.(ssa.Node)) && !prop.IsSanitizedAt(v) {


### PR DESCRIPTION
Minor cleanup pointed out in #214.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [n/a] Appropriate changes to README are included in PR

