### PR TITLE
Remove source.Classifier interface.

### DIFF
--- a/internal/pkg/levee/propagation/propagation.go
+++ b/internal/pkg/levee/propagation/propagation.go
@@ -21,6 +21,7 @@ import (
 	"go/types"
 	"log"
 
+	"github.com/google/go-flow-levee/internal/pkg/config"
 	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"github.com/google/go-flow-levee/internal/pkg/sanitizer"
 	"github.com/google/go-flow-levee/internal/pkg/source"
@@ -36,13 +37,13 @@ type Propagation struct {
 	marked       map[ssa.Node]bool
 	preOrder     []ssa.Node
 	sanitizers   []*sanitizer.Sanitizer
-	config       source.Classifier
+	config       *config.Config
 	taggedFields fieldtags.ResultType
 }
 
 // Dfs performs a depth-first search of the graph formed by SSA Referrers and
 // Operands relationships, beginning at the given root node.
-func Dfs(n ssa.Node, conf source.Classifier, taggedFields fieldtags.ResultType) Propagation {
+func Dfs(n ssa.Node, conf *config.Config, taggedFields fieldtags.ResultType) Propagation {
 	record := Propagation{
 		root:         n,
 		marked:       make(map[ssa.Node]bool),


### PR DESCRIPTION
* Replace consumption with direct *config.Config access.

----

The `source.Classifier` interface is a vestigial remnant.  `config.Config` is usable directly.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [n/a] Appropriate changes to README are included in PR
