### PR TITLE
Identify field-propagators in source analyzer.

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -61,8 +61,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				}
 
 				callee := v.Call.StaticCallee()
-				switch {
-				case callee != nil && conf.IsSink(utils.DecomposeFunction(callee)):
+				if callee != nil && conf.IsSink(utils.DecomposeFunction(callee)) {
 					for _, s := range sources {
 						prop := propagations[s.Node]
 						if prop.HasPathTo(instr.(ssa.Node)) && !prop.IsSanitizedAt(v) {

--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/google/go-flow-levee/internal/pkg/config"
-	"github.com/google/go-flow-levee/internal/pkg/fieldpropagator"
 	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"github.com/google/go-flow-levee/internal/pkg/levee/propagation"
 	"github.com/google/go-flow-levee/internal/pkg/utils"
@@ -34,7 +33,7 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 	Flags:    config.FlagSet,
 	Doc:      "reports attempts to source data to sinks",
-	Requires: []*analysis.Analyzer{source.Analyzer, fieldpropagator.Analyzer, fieldtags.Analyzer},
+	Requires: []*analysis.Analyzer{source.Analyzer, fieldtags.Analyzer},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -43,7 +42,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, err
 	}
 	sourcesMap := pass.ResultOf[source.Analyzer].(source.ResultType)
-	fieldPropagators := pass.ResultOf[fieldpropagator.Analyzer].(fieldpropagator.ResultType)
 	taggedFields := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
 
 	propagations := map[ssa.Node]propagation.Propagation{}
@@ -64,9 +62,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 				callee := v.Call.StaticCallee()
 				switch {
-				case fieldPropagators.IsFieldPropagator(v):
-					propagations[v] = propagation.Dfs(v, conf, taggedFields)
-					sources = append(sources, source.New(v))
 				case callee != nil && conf.IsSink(utils.DecomposeFunction(callee)):
 					for _, s := range sources {
 						prop := propagations[s.Node]

--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -58,8 +58,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				switch v := instr.(type) {
 
 				case *ssa.Call:
-					callee := v.Call.StaticCallee()
-					if callee != nil && conf.IsSink(utils.DecomposeFunction(callee)) {
+					if callee := v.Call.StaticCallee(); callee != nil && conf.IsSink(utils.DecomposeFunction(callee)) {
 						reportSourcesReachingSink(pass, sources, instr, propagations)
 					}
 

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -127,14 +127,14 @@ func sourcesFromBlocks(fn *ssa.Function, conf *config.Config, taggedFields field
 			default:
 				continue
 
-			// Do not mark allocation values returned by sanitizers as new sources
+			// Values produced by sanitizers are not sources.
 			case *ssa.Alloc:
 				if isProducedBySanitizer(v, conf) {
 					continue
 				}
 
-			// Do not mark values returned by sanitizers as new sources.
-			// Do mark as new sources values returned by field propagators.
+			// Values produced by sanitizers are not sources.
+			// Values produced by field propagators are.
 			case *ssa.Call:
 				if isProducedBySanitizer(v, conf) {
 					continue
@@ -142,6 +142,7 @@ func sourcesFromBlocks(fn *ssa.Function, conf *config.Config, taggedFields field
 
 				if propagators.IsFieldPropagator(v) {
 					sources = append(sources, New(v))
+					continue
 				}
 
 			// An Extract is used to obtain a value from an instruction that returns multiple values.

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -21,6 +21,7 @@ import (
 	"go/types"
 
 	"github.com/google/go-flow-levee/internal/pkg/config"
+	"github.com/google/go-flow-levee/internal/pkg/fieldpropagator"
 	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"github.com/google/go-flow-levee/internal/pkg/utils"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
@@ -63,7 +64,7 @@ func New(in ssa.Node) *Source {
 // identify individually examines each Function in the SSA code looking for Sources.
 // It produces a map relating a Function to the Sources it contains.
 // If a Function contains no Sources, it does not appear in the map.
-func identify(conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtags.ResultType) map[*ssa.Function][]*Source {
+func identify(conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) map[*ssa.Function][]*Source {
 	sourceMap := make(map[*ssa.Function][]*Source)
 
 	for _, fn := range ssaInput.SrcFuncs {
@@ -76,7 +77,7 @@ func identify(conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtag
 		var sources []*Source
 		sources = append(sources, sourcesFromParams(fn, conf, taggedFields)...)
 		sources = append(sources, sourcesFromClosures(fn, conf, taggedFields)...)
-		sources = append(sources, sourcesFromBlocks(fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromBlocks(fn, conf, taggedFields, propagators)...)
 
 		if len(sources) > 0 {
 			sourceMap[fn] = sources
@@ -114,7 +115,7 @@ func sourcesFromClosures(fn *ssa.Function, conf *config.Config, taggedFields fie
 }
 
 // sourcesFromBlocks finds Source values created by instructions within a function's body.
-func sourcesFromBlocks(fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
+func sourcesFromBlocks(fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) []*Source {
 	var sources []*Source
 	for _, b := range fn.Blocks {
 		for _, instr := range b.Instrs {
@@ -126,10 +127,21 @@ func sourcesFromBlocks(fn *ssa.Function, conf *config.Config, taggedFields field
 			default:
 				continue
 
-			// local variable or value returned from a call
-			case *ssa.Alloc, *ssa.Call:
-				if isProducedBySanitizer(v.(ssa.Value), conf) {
+			// Do not mark allocation values returned by sanitizers as new sources
+			case *ssa.Alloc:
+				if isProducedBySanitizer(v, conf) {
 					continue
+				}
+
+			// Do not mark values returned by sanitizers as new sources.
+			// Do mark as new sources values returned by field propagators.
+			case *ssa.Call:
+				if isProducedBySanitizer(v, conf) {
+					continue
+				}
+
+				if propagators.IsFieldPropagator(v) {
+					sources = append(sources, New(v))
 				}
 
 			// An Extract is used to obtain a value from an instruction that returns multiple values.


### PR DESCRIPTION
Minor additional refactor that was not in scope for #214.  This moves source identification currently in `levee` as the result of simple getters of source fields into the source-identifying analyzer.


- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [n/a] Appropriate changes to README are included in PR
