### PR TITLE
Debug: Add missing parameter edges

### DIFF
--- a/internal/pkg/debug/render/dot.go
+++ b/internal/pkg/debug/render/dot.go
@@ -56,6 +56,10 @@ func (r *renderer) writeSubgraphs() {
 }
 
 func (r *renderer) writeEdges() {
+	for _, p := range r.f.Params {
+		r.writeReferrers(p)
+	}
+
 	for _, b := range r.f.Blocks {
 		for _, i := range b.Instrs {
 			r.writeReferrers(i.(ssa.Node))

--- a/internal/pkg/debug/render/testdata/TestParams.dot
+++ b/internal/pkg/debug/render/testdata/TestParams.dot
@@ -16,6 +16,9 @@ digraph {
 		"t8 = fmt.Println(t7...)\n(Call)" [shape=rectangle];
 		"return\n(Return)" [shape=diamond];
 	}
+	"a\n(Parameter)" -> "t2 = make interface{} <- int (a)\n(MakeInterface)" [color=red];
+	"b\n(Parameter)" -> "t4 = make interface{} <- int (b)\n(MakeInterface)" [color=red];
+	"c\n(Parameter)" -> "t6 = make interface{} <- string (c)\n(MakeInterface)" [color=red];
 	"t0 = new [3]interface{} (varargs)\n(Alloc)" -> "t1 = &t0[0:int]\n(IndexAddr)" [color=red];
 	"t0 = new [3]interface{} (varargs)\n(Alloc)" -> "t3 = &t0[1:int]\n(IndexAddr)" [color=red];
 	"t0 = new [3]interface{} (varargs)\n(Alloc)" -> "t5 = &t0[2:int]\n(IndexAddr)" [color=red];


### PR DESCRIPTION
This PR adds missing referrers edges for parameters to the debug output. Missing edges can make it hard to understand exactly how/why a given traversal is working.

---

Before:

![image](https://user-images.githubusercontent.com/28677454/102223708-0cd0a300-3eb3-11eb-8fcf-dfe67d431061.png)

After:

![image](https://user-images.githubusercontent.com/28677454/102223516-d135d900-3eb2-11eb-834f-e71ae1e37e28.png)

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
