### PR TITLE
Remove title suggestions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]: "
+title: ""
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ""
 labels: bug
-assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/false-negative.md
+++ b/.github/ISSUE_TEMPLATE/false-negative.md
@@ -1,9 +1,7 @@
 ---
 name: False negative
 about: Report a false negative.
-title: ""
 labels: false negative
-assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/false-negative.md
+++ b/.github/ISSUE_TEMPLATE/false-negative.md
@@ -1,7 +1,7 @@
 ---
 name: False negative
 about: Report a false negative.
-title: "[FALSE NEGATIVE]: "
+title: ""
 labels: false negative
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/false-positive.md
+++ b/.github/ISSUE_TEMPLATE/false-positive.md
@@ -1,9 +1,7 @@
 ---
 name: False positive
 about: Report a false positive.
-title: ""
 labels: false positive
-assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/false-positive.md
+++ b/.github/ISSUE_TEMPLATE/false-positive.md
@@ -1,7 +1,7 @@
 ---
 name: False positive
 about: Report a false positive.
-title: "[FALSE POSITIVE]: "
+title: ""
 labels: false positive
 assignees: ''
 


### PR DESCRIPTION
Looking at #231, I realized that the title in the issue is redundant with the labels. Besides being redundant, it makes for a noisy title, which unnecessarily stands out from the other issues.