### PR TITLE
Gather upstream parameters into struct

### DIFF
--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -60,21 +60,12 @@ func newUpstream(pass *analysis.Pass) (upstream, error) {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	ssaInput := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
-	taggedFields := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
-	fieldPropagators := pass.ResultOf[fieldpropagator.Analyzer].(fieldpropagator.ResultType)
-
-	conf, err := config.ReadConfig()
-	if err != nil {
-		return nil, err
-	}
-
 	u, err := newUpstream(pass)
 	if err != nil {
 		return nil, err
 	}
 
-	sourceMap := identify(u, conf, ssaInput, taggedFields, fieldPropagators)
+	sourceMap := identify(u)
 
 	for _, srcs := range sourceMap {
 		for _, s := range srcs {

--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -37,21 +37,22 @@ var Analyzer = &analysis.Analyzer{
 	ResultType: reflect.TypeOf(new(ResultType)).Elem(),
 }
 
-type upstream struct {
+// TODO(do not merge): I would appreciate any suggestions for type / field names.
+// upstreamArgs bundles upstreamArgs results for cleaner function signatures.
+type upstreamArgs struct {
 	ssa   *buildssa.SSA
 	tags  fieldtags.ResultType
 	props fieldpropagator.ResultType
 	conf  *config.Config
 }
 
-func newUpstream(pass *analysis.Pass) (upstream, error) {
-
+func getUpstreamResults(pass *analysis.Pass) (upstreamArgs, error) {
 	conf, err := config.ReadConfig()
 	if err != nil {
-		return upstream{}, err
+		return upstreamArgs{}, err
 	}
 
-	return upstream{
+	return upstreamArgs{
 		ssa:   pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA),
 		tags:  pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType),
 		props: pass.ResultOf[fieldpropagator.Analyzer].(fieldpropagator.ResultType),
@@ -60,7 +61,7 @@ func newUpstream(pass *analysis.Pass) (upstream, error) {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	u, err := newUpstream(pass)
+	u, err := getUpstreamResults(pass)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -127,14 +127,14 @@ func sourcesFromBlocks(fn *ssa.Function, u upstreamArgs) []*Source {
 
 			// Values produced by sanitizers are not sources.
 			case *ssa.Alloc:
-				if isProducedBySanitizer(v, u.conf) {
+				if isProducedBySanitizer(v, u) {
 					continue
 				}
 
 			// Values produced by sanitizers are not sources.
 			// Values produced by field propagators are.
 			case *ssa.Call:
-				if isProducedBySanitizer(v, u.conf) {
+				if isProducedBySanitizer(v, u) {
 					continue
 				}
 
@@ -229,7 +229,7 @@ func hasTaggedField(taggedFields fieldtags.ResultType, s *types.Struct) bool {
 	return false
 }
 
-func isProducedBySanitizer(v ssa.Value, conf *config.Config) bool {
+func isProducedBySanitizer(v ssa.Value, u upstreamArgs) bool {
 	for _, instr := range *v.Referrers() {
 		store, ok := instr.(*ssa.Store)
 		if !ok {
@@ -239,7 +239,7 @@ func isProducedBySanitizer(v ssa.Value, conf *config.Config) bool {
 		if !ok {
 			continue
 		}
-		if callee := call.Call.StaticCallee(); callee != nil && conf.IsSanitizer(utils.DecomposeFunction(callee)) {
+		if callee := call.Call.StaticCallee(); callee != nil && u.conf.IsSanitizer(utils.DecomposeFunction(callee)) {
 			return true
 		}
 	}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -75,7 +75,7 @@ func identify(u upstream, conf *config.Config, ssaInput *buildssa.SSA, taggedFie
 		}
 
 		var sources []*Source
-		sources = append(sources, sourcesFromParams(u, fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromParams(u, fn)...)
 		sources = append(sources, sourcesFromClosures(u, fn)...)
 		sources = append(sources, sourcesFromBlocks(u, fn)...)
 
@@ -87,10 +87,10 @@ func identify(u upstream, conf *config.Config, ssaInput *buildssa.SSA, taggedFie
 }
 
 // sourcesFromParams identifies Sources that appear within a Function's parameters.
-func sourcesFromParams(u upstream, fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
+func sourcesFromParams(u upstream, fn *ssa.Function) []*Source {
 	var sources []*Source
 	for _, p := range fn.Params {
-		if IsSourceType(conf, taggedFields, p.Type()) {
+		if IsSourceType(u.conf, u.tags, p.Type()) {
 			sources = append(sources, New(p))
 		}
 	}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -73,9 +73,9 @@ func identify(u upstream) map[*ssa.Function][]*Source {
 		}
 
 		var sources []*Source
-		sources = append(sources, sourcesFromParams(u, fn)...)
-		sources = append(sources, sourcesFromClosures(u, fn)...)
-		sources = append(sources, sourcesFromBlocks(u, fn)...)
+		sources = append(sources, sourcesFromParams(fn, u)...)
+		sources = append(sources, sourcesFromClosures(fn, u)...)
+		sources = append(sources, sourcesFromBlocks(fn, u)...)
 
 		if len(sources) > 0 {
 			sourceMap[fn] = sources
@@ -85,7 +85,7 @@ func identify(u upstream) map[*ssa.Function][]*Source {
 }
 
 // sourcesFromParams identifies Sources that appear within a Function's parameters.
-func sourcesFromParams(u upstream, fn *ssa.Function) []*Source {
+func sourcesFromParams(fn *ssa.Function, u upstream) []*Source {
 	var sources []*Source
 	for _, p := range fn.Params {
 		if IsSourceType(u.conf, u.tags, p.Type()) {
@@ -99,7 +99,7 @@ func sourcesFromParams(u upstream, fn *ssa.Function) []*Source {
 // A value that is captured by a closure will appear as a Free Variable in the
 // closure. In the SSA, a Free Variable is represented as a Pointer, distinct
 // from the original value.
-func sourcesFromClosures(u upstream, fn *ssa.Function) []*Source {
+func sourcesFromClosures(fn *ssa.Function, u upstream) []*Source {
 	var sources []*Source
 	for _, p := range fn.FreeVars {
 		switch t := p.Type().(type) {
@@ -113,7 +113,7 @@ func sourcesFromClosures(u upstream, fn *ssa.Function) []*Source {
 }
 
 // sourcesFromBlocks finds Source values created by instructions within a function's body.
-func sourcesFromBlocks(u upstream, fn *ssa.Function) []*Source {
+func sourcesFromBlocks(fn *ssa.Function, u upstream) []*Source {
 	var sources []*Source
 	for _, b := range fn.Blocks {
 		for _, instr := range b.Instrs {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -64,7 +64,7 @@ func New(in ssa.Node) *Source {
 // identify individually examines each Function in the SSA code looking for Sources.
 // It produces a map relating a Function to the Sources it contains.
 // If a Function contains no Sources, it does not appear in the map.
-func identify(conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) map[*ssa.Function][]*Source {
+func identify(u upstream, conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) map[*ssa.Function][]*Source {
 	sourceMap := make(map[*ssa.Function][]*Source)
 
 	for _, fn := range ssaInput.SrcFuncs {
@@ -75,9 +75,9 @@ func identify(conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtag
 		}
 
 		var sources []*Source
-		sources = append(sources, sourcesFromParams(fn, conf, taggedFields)...)
-		sources = append(sources, sourcesFromClosures(fn, conf, taggedFields)...)
-		sources = append(sources, sourcesFromBlocks(fn, conf, taggedFields, propagators)...)
+		sources = append(sources, sourcesFromParams(u, fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromClosures(u, fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromBlocks(u, fn, conf, taggedFields, propagators)...)
 
 		if len(sources) > 0 {
 			sourceMap[fn] = sources
@@ -87,7 +87,7 @@ func identify(conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtag
 }
 
 // sourcesFromParams identifies Sources that appear within a Function's parameters.
-func sourcesFromParams(fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
+func sourcesFromParams(u upstream, fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
 	var sources []*Source
 	for _, p := range fn.Params {
 		if IsSourceType(conf, taggedFields, p.Type()) {
@@ -101,7 +101,7 @@ func sourcesFromParams(fn *ssa.Function, conf *config.Config, taggedFields field
 // A value that is captured by a closure will appear as a Free Variable in the
 // closure. In the SSA, a Free Variable is represented as a Pointer, distinct
 // from the original value.
-func sourcesFromClosures(fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
+func sourcesFromClosures(u upstream, fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
 	var sources []*Source
 	for _, p := range fn.FreeVars {
 		switch t := p.Type().(type) {
@@ -115,7 +115,7 @@ func sourcesFromClosures(fn *ssa.Function, conf *config.Config, taggedFields fie
 }
 
 // sourcesFromBlocks finds Source values created by instructions within a function's body.
-func sourcesFromBlocks(fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) []*Source {
+func sourcesFromBlocks(u upstream, fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) []*Source {
 	var sources []*Source
 	for _, b := range fn.Blocks {
 		for _, instr := range b.Instrs {

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -21,10 +21,8 @@ import (
 	"go/types"
 
 	"github.com/google/go-flow-levee/internal/pkg/config"
-	"github.com/google/go-flow-levee/internal/pkg/fieldpropagator"
 	"github.com/google/go-flow-levee/internal/pkg/fieldtags"
 	"github.com/google/go-flow-levee/internal/pkg/utils"
-	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -64,13 +62,13 @@ func New(in ssa.Node) *Source {
 // identify individually examines each Function in the SSA code looking for Sources.
 // It produces a map relating a Function to the Sources it contains.
 // If a Function contains no Sources, it does not appear in the map.
-func identify(u upstream, conf *config.Config, ssaInput *buildssa.SSA, taggedFields fieldtags.ResultType, propagators fieldpropagator.ResultType) map[*ssa.Function][]*Source {
+func identify(u upstream) map[*ssa.Function][]*Source {
 	sourceMap := make(map[*ssa.Function][]*Source)
 
-	for _, fn := range ssaInput.SrcFuncs {
+	for _, fn := range u.ssa.SrcFuncs {
 		// no need to analyze the body of sinks, nor of excluded functions
 		path, recv, name := utils.DecomposeFunction(fn)
-		if conf.IsSink(path, recv, name) || conf.IsExcluded(path, recv, name) {
+		if u.conf.IsSink(path, recv, name) || u.conf.IsExcluded(path, recv, name) {
 			continue
 		}
 

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -184,6 +184,8 @@ func sourcesFromBlocks(fn *ssa.Function, u upstreamArgs) []*Source {
 	return sources
 }
 
+// TODO(do not merge / discuss): We should consider refactoring so that this belongs to a result type rather than having propagation do direct invocation.
+// That would allow us to use the upstreamArgs + hasTaggedField as well.
 // IsSourceType determines whether a Type is a Source Type.
 // A Source Type is either:
 // - A Named Type that is classified as a Source

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -76,7 +76,7 @@ func identify(u upstream, conf *config.Config, ssaInput *buildssa.SSA, taggedFie
 
 		var sources []*Source
 		sources = append(sources, sourcesFromParams(u, fn, conf, taggedFields)...)
-		sources = append(sources, sourcesFromClosures(u, fn, conf, taggedFields)...)
+		sources = append(sources, sourcesFromClosures(u, fn)...)
 		sources = append(sources, sourcesFromBlocks(u, fn)...)
 
 		if len(sources) > 0 {
@@ -101,12 +101,12 @@ func sourcesFromParams(u upstream, fn *ssa.Function, conf *config.Config, tagged
 // A value that is captured by a closure will appear as a Free Variable in the
 // closure. In the SSA, a Free Variable is represented as a Pointer, distinct
 // from the original value.
-func sourcesFromClosures(u upstream, fn *ssa.Function, conf *config.Config, taggedFields fieldtags.ResultType) []*Source {
+func sourcesFromClosures(u upstream, fn *ssa.Function) []*Source {
 	var sources []*Source
 	for _, p := range fn.FreeVars {
 		switch t := p.Type().(type) {
 		case *types.Pointer:
-			if IsSourceType(conf, taggedFields, t) {
+			if IsSourceType(u.conf, u.tags, t) {
 				sources = append(sources, New(p))
 			}
 		}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -62,7 +62,7 @@ func New(in ssa.Node) *Source {
 // identify individually examines each Function in the SSA code looking for Sources.
 // It produces a map relating a Function to the Sources it contains.
 // If a Function contains no Sources, it does not appear in the map.
-func identify(u upstream) map[*ssa.Function][]*Source {
+func identify(u upstreamArgs) map[*ssa.Function][]*Source {
 	sourceMap := make(map[*ssa.Function][]*Source)
 
 	for _, fn := range u.ssa.SrcFuncs {
@@ -85,7 +85,7 @@ func identify(u upstream) map[*ssa.Function][]*Source {
 }
 
 // sourcesFromParams identifies Sources that appear within a Function's parameters.
-func sourcesFromParams(fn *ssa.Function, u upstream) []*Source {
+func sourcesFromParams(fn *ssa.Function, u upstreamArgs) []*Source {
 	var sources []*Source
 	for _, p := range fn.Params {
 		if IsSourceType(u.conf, u.tags, p.Type()) {
@@ -99,7 +99,7 @@ func sourcesFromParams(fn *ssa.Function, u upstream) []*Source {
 // A value that is captured by a closure will appear as a Free Variable in the
 // closure. In the SSA, a Free Variable is represented as a Pointer, distinct
 // from the original value.
-func sourcesFromClosures(fn *ssa.Function, u upstream) []*Source {
+func sourcesFromClosures(fn *ssa.Function, u upstreamArgs) []*Source {
 	var sources []*Source
 	for _, p := range fn.FreeVars {
 		switch t := p.Type().(type) {
@@ -113,7 +113,7 @@ func sourcesFromClosures(fn *ssa.Function, u upstream) []*Source {
 }
 
 // sourcesFromBlocks finds Source values created by instructions within a function's body.
-func sourcesFromBlocks(fn *ssa.Function, u upstream) []*Source {
+func sourcesFromBlocks(fn *ssa.Function, u upstreamArgs) []*Source {
 	var sources []*Source
 	for _, b := range fn.Blocks {
 		for _, instr := range b.Instrs {


### PR DESCRIPTION
This refactor was part of discussion in #223 

This PR gathers upstream analyzer results into a single struct for smaller function signatures.  Any future alterations to upstream analyzers (e.g., linking `sourceinfer`) will not require full plumbing into each method.

Exported method `IsSourceType` should not have its signature changed, as consumers would need to know implementation details of the source analyzer in order to produce the correct argument package.  Discussion on export policy should be held at the discussion PR #240.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [n/a] Appropriate changes to README are included in PR
