### PR TITLE
Discussion: Use ResultType as the de facto interface.

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -41,18 +41,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	sourcesMap := pass.ResultOf[source.Analyzer].(source.ResultType)
+	sourceResult := pass.ResultOf[source.Analyzer].(source.ResultType)
 	taggedFields := pass.ResultOf[fieldtags.Analyzer].(fieldtags.ResultType)
 
 	propagations := map[ssa.Node]propagation.Propagation{}
 
-	for _, sources := range sourcesMap {
+	for _, sources := range sourceResult.Sources {
 		for _, s := range sources {
-			propagations[s.Node] = propagation.Dfs(s.Node, conf, taggedFields)
+			propagations[s.Node] = propagation.Dfs(s.Node, conf, taggedFields, sourceResult)
 		}
 	}
 
-	for fn, sources := range sourcesMap {
+	for fn, sources := range sourceResult.Sources {
 		for _, b := range fn.Blocks {
 			for _, instr := range b.Instrs {
 				switch v := instr.(type) {

--- a/internal/pkg/levee/propagation/propagation.go
+++ b/internal/pkg/levee/propagation/propagation.go
@@ -43,7 +43,7 @@ type Propagation struct {
 
 // Dfs performs a depth-first search of the graph formed by SSA Referrers and
 // Operands relationships, beginning at the given root node.
-func Dfs(n ssa.Node, conf *config.Config, taggedFields fieldtags.ResultType) Propagation {
+func Dfs(n ssa.Node, conf *config.Config, taggedFields fieldtags.ResultType, sourceResult source.ResultType) Propagation {
 	record := Propagation{
 		root:         n,
 		marked:       make(map[ssa.Node]bool),
@@ -52,8 +52,8 @@ func Dfs(n ssa.Node, conf *config.Config, taggedFields fieldtags.ResultType) Pro
 	}
 	maxInstrReached := map[*ssa.BasicBlock]int{}
 
-	record.visitReferrers(n, maxInstrReached, nil)
-	record.dfs(n, maxInstrReached, nil, false)
+	record.visitReferrers(n, maxInstrReached, nil, sourceResult)
+	record.dfs(n, maxInstrReached, nil, false, sourceResult)
 
 	return record
 }
@@ -68,7 +68,7 @@ func Dfs(n ssa.Node, conf *config.Config, taggedFields fieldtags.ResultType) Pro
 //   a call to a sink where the argument was tainted after the call happened.
 // - lastBlockVisited is used to determine whether the next instruction to visit
 //   can be reached from the current instruction.
-func (prop *Propagation) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, isReferrer bool) {
+func (prop *Propagation) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, isReferrer bool, sourceResult source.ResultType) {
 	if prop.shouldNotVisit(n, maxInstrReached, lastBlockVisited, isReferrer) {
 		return
 	}
@@ -93,7 +93,7 @@ func (prop *Propagation) dfs(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int
 		lastBlockVisited = instr.Block()
 	}
 
-	prop.visit(n, mirCopy, lastBlockVisited)
+	prop.visit(n, mirCopy, lastBlockVisited, sourceResult)
 }
 
 func (prop *Propagation) shouldNotVisit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, isReferrer bool) bool {
@@ -130,7 +130,7 @@ func (prop *Propagation) shouldNotVisit(n ssa.Node, maxInstrReached map[*ssa.Bas
 	return false
 }
 
-func (prop *Propagation) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (prop *Propagation) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, sourceResult source.ResultType) {
 	switch t := n.(type) {
 	case *ssa.Alloc:
 		// An Alloc represents the allocation of space for a variable. If a Node is an Alloc,
@@ -141,7 +141,7 @@ func (prop *Propagation) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]i
 		// However, if the Alloc is an array, then that means the source that we are visiting from
 		// is being placed into an array, slice or varags, so we do need to keep visiting.
 		if _, isArray := utils.Dereference(t.Type()).(*types.Array); isArray {
-			prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
+			prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
 		}
 
 	case *ssa.Call:
@@ -151,14 +151,14 @@ func (prop *Propagation) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]i
 
 		// This is to avoid attaching calls where the source is the receiver, ex:
 		// core.Sinkf("Source id: %v", wrapper.Source.GetID())
-		if recv := t.Call.Signature().Recv(); recv != nil && source.IsSourceType(prop.config, prop.taggedFields, recv.Type()) {
+		if recv := t.Call.Signature().Recv(); recv != nil && sourceResult.IsSourceType(prop.config, prop.taggedFields, recv.Type()) {
 			return
 		}
 
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
 		for _, a := range t.Call.Args {
 			if canBeTaintedByCall(a.Type()) {
-				prop.dfs(a.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+				prop.dfs(a.(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 			}
 		}
 
@@ -169,53 +169,53 @@ func (prop *Propagation) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]i
 		if !prop.config.IsSourceField(typPath, typName, fieldName) && !prop.taggedFields.IsSourceFieldAddr(t) {
 			return
 		}
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
-		prop.visitOperands(n, maxInstrReached, lastBlockVisited)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
+		prop.visitOperands(n, maxInstrReached, lastBlockVisited, sourceResult)
 
 	// Everything but the actual integer Index should be visited.
 	case *ssa.Index:
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
-		prop.dfs(t.X.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
+		prop.dfs(t.X.(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 
 	// Everything but the actual integer Index should be visited.
 	case *ssa.IndexAddr:
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
-		prop.dfs(t.X.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
+		prop.dfs(t.X.(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 
 	// Only the Addr (the Value that is being written to) should be visited.
 	case *ssa.Store:
-		prop.dfs(t.Addr.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+		prop.dfs(t.Addr.(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 
 	// Only the Map itself can be tainted by an Update.
 	// The Key can't be tainted.
 	// The Value can propagate taint to the Map, but not receive it.
 	// MapUpdate has no referrers, it is only an Instruction, not a Value.
 	case *ssa.MapUpdate:
-		prop.dfs(t.Map.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+		prop.dfs(t.Map.(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 
 	// The only Operand that can be tainted by a Send is the Chan.
 	// The Value can propagate taint to the Chan, but not receive it.
 	// Send has no referrers, it is only an Instruction, not a Value.
 	case *ssa.Send:
-		prop.dfs(t.Chan.(ssa.Node), maxInstrReached, lastBlockVisited, false)
+		prop.dfs(t.Chan.(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 
 	// These nodes' operands should not be visited, because they can only receive
 	// taint from their operands, not propagate taint to them.
 	case *ssa.BinOp, *ssa.ChangeInterface, *ssa.ChangeType, *ssa.Convert, *ssa.Extract, *ssa.MakeChan, *ssa.MakeMap, *ssa.MakeSlice, *ssa.Phi, *ssa.Range:
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
 
 	// These nodes don't have operands; they are Values, not Instructions.
 	case *ssa.Const, *ssa.FreeVar, *ssa.Global, *ssa.Lookup, *ssa.Parameter:
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
 
 	// These nodes don't have referrers; they are Instructions, not Values.
 	case *ssa.Go:
-		prop.visitOperands(n, maxInstrReached, lastBlockVisited)
+		prop.visitOperands(n, maxInstrReached, lastBlockVisited, sourceResult)
 
 	// These nodes are both Instructions and Values, and currently have no special restrictions.
 	case *ssa.Field, *ssa.MakeInterface, *ssa.Select, *ssa.Slice, *ssa.TypeAssert, *ssa.UnOp:
-		prop.visitReferrers(n, maxInstrReached, lastBlockVisited)
-		prop.visitOperands(n, maxInstrReached, lastBlockVisited)
+		prop.visitReferrers(n, maxInstrReached, lastBlockVisited, sourceResult)
+		prop.visitOperands(n, maxInstrReached, lastBlockVisited, sourceResult)
 
 	// These nodes cannot propagate taint.
 	case *ssa.Builtin, *ssa.DebugRef, *ssa.Defer, *ssa.Function, *ssa.If, *ssa.Jump, *ssa.MakeClosure, *ssa.Next, *ssa.Panic, *ssa.Return, *ssa.RunDefers:
@@ -225,21 +225,21 @@ func (prop *Propagation) visit(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]i
 	}
 }
 
-func (prop *Propagation) visitReferrers(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (prop *Propagation) visitReferrers(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, sourceResult source.ResultType) {
 	if n.Referrers() == nil {
 		return
 	}
 	for _, r := range *n.Referrers() {
-		prop.dfs(r.(ssa.Node), maxInstrReached, lastBlockVisited, true)
+		prop.dfs(r.(ssa.Node), maxInstrReached, lastBlockVisited, true, sourceResult)
 	}
 }
 
-func (prop *Propagation) visitOperands(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (prop *Propagation) visitOperands(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock, sourceResult source.ResultType) {
 	for _, o := range n.Operands(nil) {
 		if *o == nil {
 			continue
 		}
-		prop.dfs((*o).(ssa.Node), maxInstrReached, lastBlockVisited, false)
+		prop.dfs((*o).(ssa.Node), maxInstrReached, lastBlockVisited, false, sourceResult)
 	}
 }
 

--- a/internal/pkg/source/analyzer.go
+++ b/internal/pkg/source/analyzer.go
@@ -16,6 +16,7 @@ package source
 
 import (
 	"go/token"
+	"go/types"
 	"reflect"
 
 	"github.com/google/go-flow-levee/internal/pkg/config"
@@ -26,7 +27,13 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
-type ResultType = map[*ssa.Function][]*Source
+type ResultType struct {
+	Sources map[*ssa.Function][]*Source
+}
+
+func (result ResultType) IsSourceType(c *config.Config, tags fieldtags.ResultType, t types.Type) bool {
+	return isSourceType(c, tags, t)
+}
 
 var Analyzer = &analysis.Analyzer{
 	Name:       "source",
@@ -55,7 +62,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 	}
 
-	return sourceMap, nil
+	return ResultType{sourceMap}, nil
 }
 
 func report(pass *analysis.Pass, pos token.Pos) {


### PR DESCRIPTION
This PR intended as discussion for neighboring PR.

While plumbing arguments down in #239, I was blocked at the exported `IsSourceType`.  It made me wonder what the meaningful distinction between a top-level function and a result method is.

This PR shifts `source.IsSourceType` to `source.ResultType.IsSourceType`.  Doing so makes the `source.ResultType` the summary interface for the `source` package and analyzer.  This would cleanly separate our internal package usage from external package consumption.  That separation gives much more modular flexibility in implementation changes.

On the other hand, it is essentially a reproduction of the Exported / Unexported model.  The real solution may really be to be more careful about consumption of exported functions by unexported methods.


- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [n/a] Appropriate changes to README are included in PR
