### PR TITLE
Refactor calls to determine if an instruction is tainted

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -78,7 +78,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func reportSourcesReachingSink(pass *analysis.Pass, sources []*source.Source, instr ssa.Instruction, propagations map[ssa.Node]propagation.Propagation) {
 	for _, s := range sources {
 		prop := propagations[s.Node]
-		if prop.HasPathTo(instr.(ssa.Node)) && !prop.IsSanitizedAt(instr) {
+		if prop.IsTainted(instr) {
 			report(pass, s, instr.(ssa.Node))
 			break
 		}

--- a/internal/pkg/levee/propagation/propagation.go
+++ b/internal/pkg/levee/propagation/propagation.go
@@ -275,15 +275,14 @@ func (prop *Propagation) canReach(start *ssa.BasicBlock, dest *ssa.BasicBlock) b
 	return false
 }
 
-// HasPathTo determines whether a Node can be reached
-// from the Propagation's root.
-func (prop Propagation) HasPathTo(n ssa.Node) bool {
-	return prop.marked[n]
+// IsTainted determines whether an instruction is tainted by the Propagation.
+func (prop Propagation) IsTainted(instr ssa.Instruction) bool {
+	return prop.marked[instr.(ssa.Node)] && !prop.isSanitizedAt(instr)
 }
 
-// IsSanitizedAt determines whether the Propagation's root is sanitized
-// when it reaches the given instruction.
-func (prop Propagation) IsSanitizedAt(instr ssa.Instruction) bool {
+// isSanitizedAt determines whether the taint propagated from the Propagation's root
+// is sanitized when it reaches the target instruction.
+func (prop Propagation) isSanitizedAt(instr ssa.Instruction) bool {
 	for _, san := range prop.sanitizers {
 		if san.Dominates(instr) {
 			return true


### PR DESCRIPTION
As a top-level, end-of-the-chain analyzer, `levee` should be able to just ask the `Propagation` if an instruction is tainted. `levee` shouldn't know about `sanitizer`s if it doesn't have to.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [ ] Appropriate changes to README are included in PR
