### PR TITLE
Document AllowPanicOnTaintedValues

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -63,6 +63,20 @@ To explicitly match an empty string, such as top-level functions without a recei
 
 Taint propagation is performed automatically and does not need to be explicitly configured.
 
+### Allowing panics on tainted values
+
+By default, the `panic` builtin is considered a sink.
+Indeed, if a tainted value reaches a call to `panic`,
+it is likely that this tainted value will escape the program's memory.
+The analyzer makes no attempt to determine whether a `panic` can actually can occur,
+nor does it try to determine whether each call to `panic` will be caught by a call to `recover`.
+
+If you do not wish `panic` to be considered a sink, add the following line to your configuration:
+
+```yaml
+AllowPanicOnTaintedValues: true
+```
+
 ### Restricting analysis scope
 
 Functions can be explicitly excluded from analysis using string literals or regexps,


### PR DESCRIPTION
Considering `panic` a sink by default and allowing users to turn off this behavior was recently added in #226. This PR adds missing documentation for this feature.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
