### PR TITLE
Reassign structlit test todos, add tests

### DIFF
--- a/internal/pkg/levee/testdata/src/example.com/tests/structlit/tests.go
+++ b/internal/pkg/levee/testdata/src/example.com/tests/structlit/tests.go
@@ -29,12 +29,44 @@ type PointerHolder struct {
 	i *core.Innocuous
 }
 
+type InterfaceHolder struct {
+	i interface{}
+}
+
+type DoubleInterfaceHolder struct {
+	i interface{}
+	j interface{}
+}
+
+func TestStructLiteralContainingTaintedInterfaceIsTainted(s core.Source) {
+	ih := InterfaceHolder{
+		s,
+	}
+	core.Sink(ih) // TODO(#212) want "a source has reached a sink"
+}
+
+func TestStructLiteralContainingTaintedAndNonTaintedInterfaceValuesIsTainted(s core.Source, i core.Innocuous) {
+	dih := DoubleInterfaceHolder{
+		s,
+		i,
+	}
+	core.Sink(dih) // TODO(#212) want "a source has reached a sink"
+}
+
+func TestStructLiteralContainingTaintedAndNonTaintedInterfaceValuesIsTaintedFlipped(s core.Source, i core.Innocuous) {
+	dih := DoubleInterfaceHolder{
+		i,
+		s,
+	}
+	core.Sink(dih) // TODO(#212) want "a source has reached a sink"
+}
+
 func TestStructHoldingSourceAndInnocIsTainted(s core.Source, i core.Innocuous) {
 	h := Holder{
 		s,
 		i,
 	}
-	core.Sink(h) // TODO(#97) want "a source has reached a sink"
+	core.Sink(h) // TODO(#212) want "a source has reached a sink"
 }
 
 func TestStructHoldingSourceAndInnocIsTaintedReverseFieldOrder(s core.Source, i core.Innocuous) {
@@ -42,7 +74,7 @@ func TestStructHoldingSourceAndInnocIsTaintedReverseFieldOrder(s core.Source, i 
 		i: i,
 		s: s,
 	}
-	core.Sink(h) // TODO(#97) want "a source has reached a sink"
+	core.Sink(h) // TODO(#212) want "a source has reached a sink"
 }
 
 func TestStructHoldingSourceAndInnocPointersIsTainted(s *core.Source, i *core.Innocuous) {
@@ -50,7 +82,7 @@ func TestStructHoldingSourceAndInnocPointersIsTainted(s *core.Source, i *core.In
 		s,
 		i,
 	}
-	core.Sink(h) // TODO(#97) want "a source has reached a sink"
+	core.Sink(h) // TODO(#212) want "a source has reached a sink"
 }
 
 func TestStructHoldingSourceAndInnocPointersIsTaintedReverseFieldOrder(s *core.Source, i *core.Innocuous) {
@@ -58,7 +90,7 @@ func TestStructHoldingSourceAndInnocPointersIsTaintedReverseFieldOrder(s *core.S
 		i: i,
 		s: s,
 	}
-	core.Sink(h) // TODO(#97) want "a source has reached a sink"
+	core.Sink(h) // TODO(#212) want "a source has reached a sink"
 }
 
 func TestAnonymousStructHoldingSourceAndInnocIsTainted(s core.Source, i core.Innocuous) {
@@ -69,7 +101,7 @@ func TestAnonymousStructHoldingSourceAndInnocIsTainted(s core.Source, i core.Inn
 		i: i,
 		s: s,
 	}
-	core.Sink(h) // TODO(#97) want "a source has reached a sink"
+	core.Sink(h) // TODO(#212) want "a source has reached a sink"
 }
 
 func TestAnonymousStructHoldingSourceAndInnocPointersIsTainted(s *core.Source, i *core.Innocuous) {
@@ -80,5 +112,5 @@ func TestAnonymousStructHoldingSourceAndInnocPointersIsTainted(s *core.Source, i
 		i: i,
 		s: s,
 	}
-	core.Sink(h) // TODO(#97) want "a source has reached a sink"
+	core.Sink(h) // TODO(#212) want "a source has reached a sink"
 }


### PR DESCRIPTION
Consider this piece of SSA graph:

![image](https://user-images.githubusercontent.com/28677454/104471104-71515180-5588-11eb-9841-de456a321c71.png)

The corresponding code is:

```go
func TestStructHoldingSourceAndInnocIsTainted(s core.Source, i core.Innocuous) {
	h := Holder{
		s,
		i,
	}
	core.Sink(h) // TODO want "a source has reached a sink"
}
```

Currently, the assigned issue is #97. While I think fixing #97 may solve this case, when I originally wrote these tests the intent was to capture the fact that if you put a source value into a locally allocated struct, that struct should be tainted. Now that I'm taking a fresh look at this, I believe the test case I wanted to write was:

```go
type InterfaceHolder struct {
	i interface{}
}

func TestStructLiteralContainingTaintedInterfaceIsTainted(s core.Source) {
	ih := InterfaceHolder{
		s,
	}
	core.Sink(ih) // TODO(#212) want "a source has reached a sink"
}
```

The SSA graph for this one is basically the same, with an extra `MakeInterface` step (and without the path involving the `core.Innocuous` value).

In all of these cases (but this is especially clear in the cases involving `interface{}` fields), propagation doesn't make it through the `Alloc`, so taint doesn't reach the sink. To me, this seems like it's a closer fit for #212.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR