### PR TITLE
Fix panic in visitCall

### DIFF
--- a/internal/pkg/propagation/propagation.go
+++ b/internal/pkg/propagation/propagation.go
@@ -258,6 +258,9 @@ func (prop *Propagation) visitCall(call *ssa.Call, maxInstrReached map[*ssa.Basi
 	// Source methods that return tainted values regardless of their arguments should be identified by the fieldpropagator analyzer.
 	if recv := call.Call.Signature().Recv(); recv != nil && sourcetype.IsSourceType(prop.config, prop.taggedFields, recv.Type()) {
 		visitingFromArg := false
+		if len(call.Call.Args) == 0 {
+			return
+		}
 		for _, a := range call.Call.Args[1:] {
 			if prop.tainted[a.(ssa.Node)] {
 				visitingFromArg = true


### PR DESCRIPTION
I'm still investigating the cause of this, just fixing the panic for now.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
