### PR TITLE
Fix yamllint issues

### DIFF
--- a/configuration/example-config.yaml
+++ b/configuration/example-config.yaml
@@ -13,20 +13,20 @@
 # limitations under the License.
 ---
 Sources:
-- TypeRE: "^Secret$|Token"
-- PackageRE: "k8s.io/client-go/tools/clientcmd/api(?:/v1)?"
-  TypeRE: "^(?:Named)?AuthInfo$"
-  FieldRE: ""
-- PackageRE: "^k8s.io/client-go/rest$"
-  TypeRE: "^TLSClientConfig$"
-  FieldRE: "Password|BearerToken$|"
-- PackageRE: "^k8s.io/client-go/rest$"
-  TypeRE: "^Config$"
-  FieldRE: "Password|BearerToken$|"
+  - TypeRE: "^Secret$|Token"
+  - PackageRE: "k8s.io/client-go/tools/clientcmd/api(?:/v1)?"
+    TypeRE: "^(?:Named)?AuthInfo$"
+    FieldRE: ""
+  - PackageRE: "^k8s.io/client-go/rest$"
+    TypeRE: "^TLSClientConfig$"
+    FieldRE: "Password|BearerToken$|"
+  - PackageRE: "^k8s.io/client-go/rest$"
+    TypeRE: "^Config$"
+    FieldRE: "Password|BearerToken$|"
 Sinks:
-- PackageRE: "log"
-  ReceiverRE: ""
-  MethodRE: "Info|Warning|Error|Fatal|Exit"
+  - PackageRE: "log"
+    ReceiverRE: ""
+    MethodRE: "Info|Warning|Error|Fatal|Exit"
 Sanitizers: []
 Exclude:
-- PackageRE: "^k8s.io/kubernetes/test"
+  - PackageRE: "^k8s.io/kubernetes/test"

--- a/internal/pkg/fieldpropagator/testdata/test-config.yaml
+++ b/internal/pkg/fieldpropagator/testdata/test-config.yaml
@@ -13,15 +13,15 @@
 # limitations under the License.
 ---
 Sources:
-- PackageRE: source
-  TypeRE: "^Source$"
-  FieldRE: "^data"
-- Package: proto
-  Type: KeyPair
-  Field: Private
-- Package: proto
-  Type: TLS
-  Field: Cert
-- Package: proto
-  Type: BasicAuth
-  Field: Password
+  - PackageRE: source
+    TypeRE: "^Source$"
+    FieldRE: "^data"
+  - Package: proto
+    Type: KeyPair
+    Field: Private
+  - Package: proto
+    Type: TLS
+    Field: Cert
+  - Package: proto
+    Type: BasicAuth
+    Field: Password

--- a/internal/pkg/fieldtags/testdata/test-config.yaml
+++ b/internal/pkg/fieldtags/testdata/test-config.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 ---
 FieldTags:
-- Key: example
-  Val: sensitive
+  - Key: example
+    Val: sensitive

--- a/internal/pkg/levee/testdata/allowpanicontaintedvalues-config.yaml
+++ b/internal/pkg/levee/testdata/allowpanicontaintedvalues-config.yaml
@@ -14,9 +14,9 @@
 ---
 AllowPanicOnTaintedValues: true
 Sources:
-- Package: "nopanic.com/core"
-  Type: "Source"
-  Field: "Data"
+  - Package: "nopanic.com/core"
+    Type: "Source"
+    Field: "Data"
 Sinks:
-- Package: "nopanic.com/core"
-  Method: "Sink"
+  - Package: "nopanic.com/core"
+    Method: "Sink"

--- a/internal/pkg/levee/testdata/no-custom-message.yaml
+++ b/internal/pkg/levee/testdata/no-custom-message.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 Sources:
-- Type: Source
+  - Type: Source
 
 Sinks:
-- Method: Sink
+  - Method: Sink

--- a/internal/pkg/levee/testdata/test-config.yaml
+++ b/internal/pkg/levee/testdata/test-config.yaml
@@ -13,19 +13,19 @@
 # limitations under the License.
 ---
 Sources:
-- PackageRE: "^example.com/core$"
-  TypeRE: "^Source$"
-  FieldRE: "^Data"
+  - PackageRE: "^example.com/core$"
+    TypeRE: "^Source$"
+    FieldRE: "^Data"
 Sinks:
-- PackageRE: "^example.com/core$"
-  MethodRE: Sinkf?$
+  - PackageRE: "^example.com/core$"
+    MethodRE: Sinkf?$
 Sanitizers:
-- PackageRE: "^example.com/core$"
-  MethodRE: "^Sanitize"
+  - PackageRE: "^example.com/core$"
+    MethodRE: "^Sanitize"
 Exclude:
-- PackageRE: "^example.com/tests/excludedpackage$"
-- PackageRE: "^example.com/tests/includedpackage$"
-  MethodRE: "^Oops$"
-- PackageRE: "^example.com/tests/includedpackage$"
-  MethodRE: "^OopsWithReceiverExcluded$"
-  ReceiverRE: "^Receiver$"
+  - PackageRE: "^example.com/tests/excludedpackage$"
+  - PackageRE: "^example.com/tests/includedpackage$"
+    MethodRE: "^Oops$"
+  - PackageRE: "^example.com/tests/includedpackage$"
+    MethodRE: "^OopsWithReceiverExcluded$"
+    ReceiverRE: "^Receiver$"

--- a/internal/pkg/levee/testdata/with-custom-message.yaml
+++ b/internal/pkg/levee/testdata/with-custom-message.yaml
@@ -15,7 +15,7 @@
 ReportMessage: This custom message is included with report.
 
 Sources:
-- Type: Source
+  - Type: Source
 
 Sinks:
-- Method: Sink
+  - Method: Sink

--- a/internal/pkg/source/testdata/src/analyzertest/test-config.yaml
+++ b/internal/pkg/source/testdata/src/analyzertest/test-config.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 ---
 Sources:
-- PackageRE: ""
-  TypeRE: "^Source$"
-  FieldRE: "^Data"
-# The below cannot actually be a Source, because it is an interface type
-- PackageRE: ""
-  Type: "SourceInterface"
+  - PackageRE: ""
+    TypeRE: "^Source$"
+    FieldRE: "^Data"
+  # The below cannot actually be a Source, because it is an interface type
+  - PackageRE: ""
+    Type: "SourceInterface"

--- a/internal/pkg/sourceinfer/testdata/test-config.yaml
+++ b/internal/pkg/sourceinfer/testdata/test-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 Sources:
-- PackageRE: "^example.com/source$"
-  TypeRE: "^Source$"
-- PackageRE: "^example.com/tests/samepkg$"
-  TypeRE: "^Source$"
+  - PackageRE: "^example.com/source$"
+    TypeRE: "^Source$"
+  - PackageRE: "^example.com/tests/samepkg$"
+    TypeRE: "^Source$"


### PR DESCRIPTION
This PR builds on #268. In that PR, I disabled the `yamllint` check, because it was failing.

This PR fixes the `yamllint` errors and reenables the check.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
