### PR TITLE
Rename propagation methods: visit --> taint

### DIFF
--- a/internal/pkg/propagation/propagation.go
+++ b/internal/pkg/propagation/propagation.go
@@ -146,7 +146,7 @@ func (prop *Propagation) taintNeighbors(n ssa.Node, maxInstrReached map[*ssa.Bas
 		}
 
 	case *ssa.Call:
-		prop.visitCall(t, maxInstrReached, lastBlockVisited)
+		prop.taintCall(t, maxInstrReached, lastBlockVisited)
 
 	case *ssa.Field:
 		prop.taintField(n, maxInstrReached, lastBlockVisited, t.X.Type(), t.Field)
@@ -176,7 +176,7 @@ func (prop *Propagation) taintNeighbors(n ssa.Node, maxInstrReached map[*ssa.Bas
 		prop.taint(t.Map.(ssa.Node), maxInstrReached, lastBlockVisited, false)
 
 	case *ssa.Select:
-		prop.visitSelect(t, maxInstrReached, lastBlockVisited)
+		prop.taintSelect(t, maxInstrReached, lastBlockVisited)
 
 	// The only Operand that can be tainted by a Send is the Chan.
 	// The Value can propagate taint to the Chan, but not receive it.
@@ -242,10 +242,10 @@ func (prop *Propagation) taintOperands(n ssa.Node, maxInstrReached map[*ssa.Basi
 	}
 }
 
-func (prop *Propagation) visitCall(call *ssa.Call, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (prop *Propagation) taintCall(call *ssa.Call, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
 	// Some builtins require special handling
 	if builtin, ok := call.Call.Value.(*ssa.Builtin); ok {
-		prop.visitBuiltin(call, builtin.Name(), maxInstrReached, lastBlockVisited)
+		prop.taintBuiltin(call, builtin.Name(), maxInstrReached, lastBlockVisited)
 		return
 	}
 
@@ -286,7 +286,7 @@ func (prop *Propagation) visitCall(call *ssa.Call, maxInstrReached map[*ssa.Basi
 	}
 }
 
-func (prop *Propagation) visitBuiltin(c *ssa.Call, builtinName string, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (prop *Propagation) taintBuiltin(c *ssa.Call, builtinName string, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
 	switch builtinName {
 	// The values being appended cannot be tainted.
 	case "append":
@@ -310,7 +310,7 @@ func (prop *Propagation) taintCallArg(arg ssa.Value, maxInstrReached map[*ssa.Ba
 	}
 }
 
-func (prop *Propagation) visitSelect(sel *ssa.Select, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+func (prop *Propagation) taintSelect(sel *ssa.Select, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
 	// Select returns a tuple whose first 2 elements are irrelevant for our
 	// analysis. Subsequent elements correspond to Recv states, which map
 	// 1:1 with Extracts.


### PR DESCRIPTION
Ran into this while looking at other stuff. Most methods were renamed away from `visit` and towards `taint` in a past PR (#225), but these lingered, likely due to concurrent changes.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR