### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -137,7 +137,6 @@ func TestDecomposeField(t *testing.T) {
 			res := r[0].Result.(testAnalyzerResult)
 
 			fa := res.fieldAddr[0]
-			fmt.Println(fa.Pos())
 
 			typePath, typeName, fieldName := DecomposeField(fa.X.Type(), fa.Field)
 			if typePath != tt.typePath {


### PR DESCRIPTION
I noticed this noisy output when inspecting the output of the `test` job in our CI. This seems to have been introduced for debugging, but it is not needed and it just produces noise.

Example output:

```
=== RUN   TestDecomposeField/regular
0
=== RUN   TestDecomposeField/embedded
0
``` 

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
