### PR TITLE
[Draft] Trace taint when reporting.

### DIFF
--- a/internal/pkg/levee/testdata/src/levee_analysistest/custom.message.com/nocustom/nocustom.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/custom.message.com/nocustom/nocustom.go
@@ -23,5 +23,6 @@ func Sink(interface{}) {}
 
 func TestReportMessage() {
 	s := Source{Data: "password", ID: 1337}
-	Sink(s) // want "^a source has reached a sink\n source: .*custom.go:25:2$"
+	// TODO revert before merging
+	Sink(s) // want ".*"
 }

--- a/internal/pkg/levee/testdata/src/levee_analysistest/custom.message.com/withcustom/withcustom.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/custom.message.com/withcustom/withcustom.go
@@ -23,5 +23,6 @@ func Sink(interface{}) {}
 
 func TestReportMessage() {
 	s := Source{Data: "password", ID: 1337}
-	Sink(s) // want "^a source has reached a sink\n source: .*custom.go:25:2\n This custom message is included with report.$"
+	// TODO revert before merging
+	Sink(s) // want ".*"
 }

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/callorder/colocation.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/callorder/colocation.go
@@ -32,7 +32,7 @@ func TestTaintedColocatedArgumentReachesSinkThatFollowsColocation() {
 	i := newInnocuous()
 	taintColocated(s, i)
 	if err := fail(i); err != nil {
-		core.Sink(err) // want "a source has reached a sink"
+		core.Sink(err) // This want removed to demonstrate output
 	}
 }
 

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/collections/arrays.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/collections/arrays.go
@@ -26,7 +26,7 @@ func TestArrayLiteralContainingSourceIsTainted(s core.Source) {
 func TestArrayIsTaintedWhenSourceIsInserted(s core.Source) {
 	arr := [2]interface{}{nil, nil}
 	arr[0] = s
-	core.Sink(arr) // want "a source has reached a sink"
+	core.Sink(arr) // This want removed to demonstrate output
 }
 
 func TestValueObtainedFromTaintedArrayIsTainted(s core.Source) {

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/loops/tests.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/loops/tests.go
@@ -91,7 +91,7 @@ func TestTaintPropagationOverMultipleIterations() {
 		}
 	}
 	core.Sink(e1) // want "a source has reached a sink"
-	core.Sink(e2) // want "a source has reached a sink"
+	core.Sink(e2) // This want removed to demonstrate output
 }
 
 func TestTaintPropagationOverMultipleIterationsWithNestedConditionals() {

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/position/tests.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/position/tests.go
@@ -20,7 +20,8 @@ import (
 
 func TestSourcePointerExtract() {
 	s, _ := NewSource()
-	core.Sink(s) // want "a source has reached a sink\n source: .*tests.go:22:19"
+	// TODO revert before merging
+	core.Sink(s) // want "a source .*"
 }
 
 // In order for the SSA to contain a FieldAddr, the EmbedsSource instance's fields have to be addressable.
@@ -33,13 +34,15 @@ func TestSourcePointerExtract() {
 func TestEmbeddedSourceFieldAddr() {
 	es := EmbedsSource{}
 	d := es.Data
-	core.Sink(d) // want "a source has reached a sink\n source: .*tests.go:34:2"
+	// TODO revert before merging
+	core.Sink(d) // want "a source .*"
 }
 
 // In order for the SSA to contain a Field, the EmbedsSource instance's fields must not be addressable.
 // One way to do this is to create a literal and to access the field directly, as part of the same expression.
 func TestEmbeddedSourceField() {
-	core.Sink(EmbedsSource{}.Data) // want "a source has reached a sink\n source: .*tests.go:42:24"
+	// TODO revert before merging
+	core.Sink(EmbedsSource{}.Data) // want "a source .*"
 }
 
 type EmbedsSource struct {

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/sanitization/tests.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/sanitization/tests.go
@@ -83,8 +83,7 @@ func TestMaybeTaintedInLoopButSanitizedBeforeLoopExit() {
 		}
 		e = core.Sanitize(e)[0]
 	}
-	// TODO(#155) want no report here
-	core.Sink(e) // want "a source has reached a sink"
+	core.Sink(e)
 }
 
 func TestTaintedInIfButSanitizedBeforeIfExit() {
@@ -93,8 +92,7 @@ func TestTaintedInIfButSanitizedBeforeIfExit() {
 		e = core.Source{}
 		e = core.Sanitize(e)[0]
 	}
-	// TODO(#155) want no report here
-	core.Sink(e) // want "a source has reached a sink"
+	core.Sink(e)
 }
 
 func TestPointerTaintedInIfButSanitizedBeforeIfExit() {


### PR DESCRIPTION
* Partially addresses #155

----

Themes of this PR:

* Introduce taint tracing by converting `tainted map[Node]bool` to `taintedBy map[Node]Node`.
    * Plumb necessary arguments through taint signatures
* Refactor `taintCall` so that removing taint from `Call` does not break taint trace.
    * Removing taint from the `Call` can break the taint chain entirely.  Taint now propagates directly between arguments rather than requiring propagation through the `Call`.
* Intentionally failing tests demonstrate trace output.
* Required to graduate from draft:
    * Make trace output configure controlled
    * Validate trace path produced
    * Merge #280
    * Restore tests to working order.