### PR TITLE
Always run all lint checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,14 +27,16 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Check goimports
+        if: ${{ always() }}
         run: |
-          go install golang.org/x/tools/cmd/goimports
+          GO111MODULE=off go install golang.org/x/tools/cmd/goimports
           if [[ $(goimports -l cmd internal pkg) ]]; then
             echo 'Please run `goimports -w cmd internal pkg`.'
             false
           fi
 
       - name: Check go mod
+        if: ${{ always() }}
         run: |
           go mod tidy
           if ! git diff --quiet; then
@@ -43,16 +45,19 @@ jobs:
           fi
 
       - name: Check for license headers
+        if: ${{ always() }}
         run: |
-          go get -u github.com/google/addlicense
+          GO111MODULE=off go get -u github.com/google/addlicense
           addlicense -check cmd internal pkg
 
       - name: Run staticcheck
+        if: ${{ always() }}
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck
+          GO111MODULE=off go install honnef.co/go/tools/cmd/staticcheck
           staticcheck ./...
 
       - name: Check YAML
+        if: ${{ always() }}
         run: |
           yamllint .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Check goimports
         if: ${{ always() }}
         run: |
-          GO111MODULE=off go install golang.org/x/tools/cmd/goimports
+          go install golang.org/x/tools/cmd/goimports
           if [[ $(goimports -l cmd internal pkg) ]]; then
             echo 'Please run `goimports -w cmd internal pkg`.'
             false
@@ -47,13 +47,13 @@ jobs:
       - name: Check for license headers
         if: ${{ always() }}
         run: |
-          GO111MODULE=off go get -u github.com/google/addlicense
+          go get -u github.com/google/addlicense
           addlicense -check cmd internal pkg
 
       - name: Run staticcheck
         if: ${{ always() }}
         run: |
-          GO111MODULE=off go install honnef.co/go/tools/cmd/staticcheck
+          go install honnef.co/go/tools/cmd/staticcheck
           staticcheck ./...
 
       - name: Check YAML

--- a/cmd/levee/main.go
+++ b/cmd/levee/main.go
@@ -1,17 +1,3 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package main
 
 import (
@@ -21,4 +7,8 @@ import (
 
 func main() {
 	singlechecker.Main(levee.Analyzer)
+}
+
+func unused() {
+	// staticcheck should complain
 }

--- a/cmd/levee/main.go
+++ b/cmd/levee/main.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -7,8 +21,4 @@ import (
 
 func main() {
 	singlechecker.Main(levee.Analyzer)
-}
-
-func unused() {
-	// staticcheck should complain
 }


### PR DESCRIPTION
I got the idea for this PR from #285.

When running lints in Github Actions, currently the `CI / Lint` job stops on the first failure. I think it would be preferable to always run all checks. That way if there are errors in multiple lints, they can all be observed and corrected with a single run, instead of having to repeat the "push --> check lint --> fix" cycle multiple times.

I tried using `GO111MODULE=off` on `go get` and `go install` invocations to ensure `go.{mod,sum}` wouldn't be modified when installing `addlicense` and `staticcheck`, but it doesn't work in GithubActions and I don't believe it's worth debugging now. Github Actions steps run serially, and there is currently no way to run them in parallel (cf: https://github.community/t/steps-in-parallel/16343). As long as the `Check go mod` step is before the steps that install `addlicense` and `staticcheck`, this won't cause a spurious failure.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR