### PR TITLE
Do not visit referrers of non-string basic-typed values

### DIFF
--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/basictypes/tests.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/basictypes/tests.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package basic
+
+import (
+	"levee_analysistest/example/core"
+)
+
+func BooleansDontPropagateTaint(s *core.Source) {
+	is := isSourcey(s)
+	core.Sink(is)
+}
+
+func isSourcey(x interface{}) bool {
+	// not taking any chances
+	return true
+}
+
+func IntegersDontPropagateTaint(sources []core.Source) {
+	sourceCount := countSources(sources)
+	core.Sink(sourceCount)
+}
+
+func countSources(sources []core.Source) int {
+	return len(sources)
+}

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/basictypes/tests.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/basictypes/tests.go
@@ -29,10 +29,5 @@ func isSourcey(x interface{}) bool {
 }
 
 func IntegersDontPropagateTaint(sources []core.Source) {
-	sourceCount := countSources(sources)
-	core.Sink(sourceCount)
-}
-
-func countSources(sources []core.Source) int {
-	return len(sources)
+	core.Sink(len(sources))
 }

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/extracts/tests.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/extracts/tests.go
@@ -80,8 +80,8 @@ func TestOnlySourceExtractIsTaintedInstructionOrderFlipped() {
 func TestExtractsFromCallWithSourceArgAreTainted(s core.Source) {
 	str, i, e := TakeSource(s)
 	core.Sink(str) // want "a source has reached a sink"
-	core.Sink(i)   // want "a source has reached a sink"
-	core.Sink(e)   // want "a source has reached a sink"
+	core.Sink(i)
+	core.Sink(e) // want "a source has reached a sink"
 }
 
 func NewSource() (*core.Source, error) {

--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/propagation/builtins.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/propagation/builtins.go
@@ -20,7 +20,8 @@ import (
 
 func TestCopyPropagatesTaintFromSrcToDst(s core.Source) {
 	b := make([]byte, len(s.Data))
-	copy(b, s.Data)
+	bytesCopied := copy(b, s.Data)
+	core.Sink(bytesCopied)
 	core.Sink(b) // want "a source has reached a sink"
 }
 

--- a/internal/pkg/propagation/propagation.go
+++ b/internal/pkg/propagation/propagation.go
@@ -102,10 +102,6 @@ func (prop *Propagation) shouldNotTaint(n ssa.Node, maxInstrReached map[*ssa.Bas
 		return true
 	}
 
-	if !hasTaintableType(n) {
-		return true
-	}
-
 	if instr, ok := n.(ssa.Instruction); ok {
 		instrIndex, ok := indexInBlock(instr)
 		if !ok {
@@ -225,6 +221,10 @@ func (prop *Propagation) taintField(n ssa.Node, maxInstrReached map[*ssa.BasicBl
 }
 
 func (prop *Propagation) taintReferrers(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+	if !hasTaintableType(n) {
+		return
+	}
+
 	if n.Referrers() == nil {
 		return
 	}
@@ -417,7 +417,7 @@ func hasTaintableType(n ssa.Node) bool {
 	if v, ok := n.(ssa.Value); ok {
 		switch t := v.Type().(type) {
 		case *types.Basic:
-			return t.Info() != types.IsBoolean
+			return (t.Info() & types.IsString) != 0
 		case *types.Signature:
 			return false
 		}


### PR DESCRIPTION
Fixes #191.

We've known that this could cause problems for a while, but we never hit an actual false positive because of it until recently. Motivating example:

```go
core.Sink(len(source.Data))
```

(where `source` has type `core.Source`)

See #191 for the list of basic types. My assessment is that `string`s are the only basic type that can meaningfully be tainted. Note that e.g. `[]byte` is not a basic type, its type is `Slice`, and its `Elem()` is `byte`. This does mean however that we won't catch pathological cases such as the following:

```go
for _, b := range "password" {
        core.Sink(b)
}
```

(Imagine that `core.Sink` behaves like `fmt.Print`, e.g.)

I've never observed anything like the above in the wild, so I think avoiding non-string basics is reasonable.

Something about this PR may surprise you: why move the `hasTaintableType` check from `shouldNotTaint` to `taintReferrers`? Consider this example:

```
func TestCopyPropagatesTaintFromSrcToDst(s core.Source) {
	b := make([]byte, len(s.Data))
	bytesCopied := copy(b, s.Data)
	core.Sink(bytesCopied)
	core.Sink(b) // want "a source has reached a sink"
}
```

What is the type of the `Call` to `copy` in the above? That's right, `int`. If we check whether the type is taintable in `shouldNotTaint`, we'll conclude that we shouldn't taint the `Call`, which means we won't propagate any taint through `copy`. This can occur for any other function that returns a non-string basic type. I think it's fine to taint a `bool` or an `int` (e.g.), as long as we don't then propagate to that `bool` or `int`'s referrers.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
