### PR TITLE
Fix bug: do not skip instructions that return types that aren't taintable

### DIFF
--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/propagation/functions.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/propagation/functions.go
@@ -43,3 +43,13 @@ func TestPropagationViaSourceMethod(s core.Source) {
 	tainted := s.Propagate(s.Data)
 	core.Sink(tainted) // want "a source has reached a sink"
 }
+
+func TestPropagationViaFunctionReturningBool(s *core.Source, i *core.Innocuous) {
+	if ok := TryCopy(i, s); !ok {
+		core.Sinkf("couldn't copy to: %v", i) // want "a source has reached a sink"
+	}
+}
+
+func TryCopy(dst interface{}, src interface{}) bool {
+	return true
+}

--- a/internal/pkg/propagation/propagation.go
+++ b/internal/pkg/propagation/propagation.go
@@ -102,10 +102,6 @@ func (prop *Propagation) shouldNotTaint(n ssa.Node, maxInstrReached map[*ssa.Bas
 		return true
 	}
 
-	if !hasTaintableType(n) {
-		return true
-	}
-
 	if instr, ok := n.(ssa.Instruction); ok {
 		instrIndex, ok := indexInBlock(instr)
 		if !ok {
@@ -225,6 +221,10 @@ func (prop *Propagation) taintField(n ssa.Node, maxInstrReached map[*ssa.BasicBl
 }
 
 func (prop *Propagation) taintReferrers(n ssa.Node, maxInstrReached map[*ssa.BasicBlock]int, lastBlockVisited *ssa.BasicBlock) {
+	if !hasTaintableType(n) {
+		return
+	}
+
 	if n.Referrers() == nil {
 		return
 	}


### PR DESCRIPTION
This fixes a bug discovered in #287. See that PR for details.

TLDR: When checking whether we should avoid a given `SSA` node based on its type (e.g., `bool` values can't be tainted), we should still do propagate to the operands if we normally would. We should avoid the node's referrers though, because that can lead to incorrect propagations. See the test case added by this PR for an example.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
