### PR TITLE
Print errors when config loading fails

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -314,11 +314,13 @@ func (r *configCacheElement) readOnce() (*Config, error) {
 		c := new(Config)
 		bytes, err := ioutil.ReadFile(r.sourceFile)
 		if err != nil {
+			fmt.Println(err)
 			r.err = fmt.Errorf("error reading analysis config: %v", err)
 			return
 		}
 
 		if err := yaml.UnmarshalStrict(bytes, c); err != nil {
+			fmt.Println(err)
 			r.err = err
 			return
 		}


### PR DESCRIPTION
This PR adds some `fmt.Println` calls so we can see the error message when an error occurs while loading or parsing the config. This can make such errors easier to debug.

## Before

```
levee: failed prerequisites: fieldtags, source
```

## Now

```
levee: failed prerequisites: fieldtags, source
# sync
error unmarshaling JSON: while decoding JSON: Val is not a valid config field for fieldTagMatcher, expect one of: [key value]
# errors
error unmarshaling JSON: while decoding JSON: Val is not a valid config field for fieldTagMatcher, expect one of: [key value]
# sort
error unmarshaling JSON: while decoding JSON: Val is not a valid config field for fieldTagMatcher, expect one of: [key value]
```

## A few comments
* If the config loads fine, then nothing will be printed.
* Ideally, we would want to print the error just once and then exit, but I don't see a simple way to do that. I think seeing the same message a bunch of times is preferable to not seeing the detailed error at all.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [] Appropriate changes to README are included in PR