### PR TITLE
Rename internal/pkg/levee package name

### DIFF
--- a/internal/pkg/levee/levee.go
+++ b/internal/pkg/levee/levee.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package levee
 
 import (
 	"fmt"

--- a/internal/pkg/levee/levee_test.go
+++ b/internal/pkg/levee/levee_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package levee
 
 import (
 	"flag"

--- a/pkg/levee/levee.go
+++ b/pkg/levee/levee.go
@@ -15,7 +15,7 @@
 // Package levee exports the levee Analyzer.
 package levee
 
-import internal "github.com/google/go-flow-levee/internal/pkg/levee"
+import "github.com/google/go-flow-levee/internal/pkg/levee"
 
 // Analyzer reports instances of source data reaching a sink.
-var Analyzer = internal.Analyzer
+var Analyzer = levee.Analyzer


### PR DESCRIPTION
The package name for files in `internal/pkg/levee` should be `levee` to match the directory name. (Currently, the package is named `internal`, for no apparent reason.)

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
