### PR TITLE
Allow summaries to be added externally.

### DIFF
--- a/internal/pkg/propagation/summary/api.go
+++ b/internal/pkg/propagation/summary/api.go
@@ -30,10 +30,10 @@ import (
 // For returns the summary for a given call if it exists,
 // or nil if no summary matches the called function.
 func For(call *ssa.Call) *Summary {
-	if summ, ok := funcSummaries[staticFuncName(call)]; ok {
+	if summ, ok := FuncSummaries[staticFuncName(call)]; ok {
 		return &summ
 	}
-	if summ, ok := interfaceFuncSummaries[funcKey{methodNameWithoutReceiver(call), sigTypeString(call.Call.Signature())}]; ok {
+	if summ, ok := InterfaceFuncSummaries[funcKey{methodNameWithoutReceiver(call), sigTypeString(call.Call.Signature())}]; ok {
 		return &summ
 	}
 	return nil

--- a/internal/pkg/propagation/summary/summaries.go
+++ b/internal/pkg/propagation/summary/summaries.go
@@ -31,9 +31,9 @@ var fromFirstArgToFirstRet = Summary{
 	TaintedRets: []int{0},
 }
 
-// funcSummaries contains summaries for regular functions
+// FuncSummaries contains summaries for regular functions
 // that could be called statically.
-var funcSummaries = map[string]Summary{
+var FuncSummaries = map[string]Summary{
 	// func Errorf(format string, a ...interface{}) error
 	"fmt.Errorf": {
 		IfTainted:   first | second,
@@ -642,13 +642,13 @@ type funcKey struct {
 	name, signature string
 }
 
-// interfaceFuncSummaries contains summaries for common interface functions
+// InterfaceFuncSummaries contains summaries for common interface functions
 // such as Write or Read, that could be called statically (i.e. a call to
 // a concrete method whose signature matches an interface method) or dynamically
 // (i.e. a call to an interface method on an interface value).
 // Since all of these functions have receivers, the "first" argument in `ifTainted`
 // always corresponds to the receiver.
-var interfaceFuncSummaries = map[funcKey]Summary{
+var InterfaceFuncSummaries = map[funcKey]Summary{
 	// type io.Reader interface {
 	//  Read(p []byte) (n int, err error)
 	// }

--- a/pkg/levee/levee.go
+++ b/pkg/levee/levee.go
@@ -15,7 +15,18 @@
 // Package levee exports the levee Analyzer.
 package levee
 
-import "github.com/google/go-flow-levee/internal/pkg/levee"
+import (
+	"github.com/google/go-flow-levee/internal/pkg/levee"
+	"github.com/google/go-flow-levee/internal/pkg/propagation/summary"
+)
 
 // Analyzer reports instances of source data reaching a sink.
 var Analyzer = levee.Analyzer
+
+// FuncSummaries is a wrapper around the propagation/summary
+// package's map of regular function summaries.
+var FuncSummaries = summary.FuncSummaries
+
+// InterfaceFuncSummaries is a wrapper around the propagation/summary
+// package's map of interface function summaries.
+var InterfaceFuncSummaries = summary.InterfaceFuncSummaries


### PR DESCRIPTION
This change exposes the summaries maps so that additional summaries may be added if needed.

Like #297, this is an advanced feature and I am not sure if or how we should document it.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [ ] Appropriate changes to README are included in PR
