### PR TITLE
Expose Summary data type.

### DIFF
--- a/pkg/levee/levee.go
+++ b/pkg/levee/levee.go
@@ -27,6 +27,10 @@ var Analyzer = levee.Analyzer
 // SetBytes is a wrapper around the config package's SetBytes function.
 var SetBytes = config.SetBytes
 
+// Summary is a wrapper around the propagation/summary
+// package's Summary type.
+type Summary = summary.Summary
+
 // FuncSummaries is a wrapper around the propagation/summary
 // package's map of regular function summaries.
 var FuncSummaries = summary.FuncSummaries


### PR DESCRIPTION
This is an oversight that should have been included in #298. It is currently impossible to add summaries to the summary package's exposed maps because the `Summary` type itself cannot be imported by external code.

- (N/A) [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR