### PR TITLE
Avoid config bytes data races.

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -35,6 +35,7 @@ var (
 	configFile string
 
 	configBytes        []byte
+	configBytesOnce    sync.Once
 	configFromBytes    *Config
 	configFromBytesErr error
 )
@@ -318,14 +319,13 @@ func ReadConfig() (*Config, error) {
 }
 
 func readConfigBytes() (*Config, error) {
-	if configFromBytes == nil {
-		unmarshalled := new(Config)
-		unmarshalledErr := yaml.UnmarshalStrict(configBytes, unmarshalled)
-		if unmarshalledErr != nil {
-			fmt.Println(unmarshalledErr)
+	configBytesOnce.Do(func() {
+		configFromBytes = new(Config)
+		configFromBytesErr = yaml.UnmarshalStrict(configBytes, configFromBytes)
+		if configFromBytesErr != nil {
+			fmt.Println(configFromBytesErr)
 		}
-		configFromBytes, configFromBytesErr = unmarshalled, unmarshalledErr
-	}
+	})
 
 	return configFromBytes, configFromBytesErr
 }


### PR DESCRIPTION
This change fixes an incorrect assumption we made while thinking about #297.

Even though the same config and error values will always be written to `configFromBytes` and `configFromBytesErr`, `configFromBytes` is stateful (most notably, because of the regexps), so it is possible that a data race could actually cause an issue, e.g. a regexp object is swapped out while a match is attempted, causing the match to fail. I have not actually observed this, and indeed when running #297 on `kubernetes/kubernetes` and on one other large codebase, everything seemed to be working fine. However, given the nature of data races, I think it is best to be safe here.

There is no performance impact AFAICT.

- [x] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- (N/A) [ ] Appropriate changes to README are included in PR
