### PR TITLE
chore: fix spelling

### DIFF
--- a/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/collections/sources.go
+++ b/internal/pkg/levee/testdata/src/levee_analysistest/example/tests/collections/sources.go
@@ -65,7 +65,7 @@ func TestSourceCollectionInStructFieldIsSource() {
 
 type SourceSlice []core.Source
 
-func TestAliasedSourceSollectionIsSource() {
+func TestAliasedSourceCollectionIsSource() {
 	core.Sink(SourceSlice{}) // want "a source has reached a sink"
 }
 

--- a/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
+++ b/internal/pkg/source/testdata/src/analyzertest/sourcetest/identification.go
@@ -64,15 +64,15 @@ func TestSourceDeclarations() {
 	var ptr *Source
 	// We do want a "source identified" here.
 	// ptr does not get optimized out because it gets assigned.
-	ptr = &Source{}                                       // want "source identified"
-	newPtr := new(Source)                                 // want "source identified"
-	ptrToDeclZero := &Source{}                            // want "source identified"
-	ptrToDeclPopulataed := &Source{Data: "secret", ID: 1} // want "source identified"
+	ptr = &Source{}                                      // want "source identified"
+	newPtr := new(Source)                                // want "source identified"
+	ptrToDeclZero := &Source{}                           // want "source identified"
+	ptrToDeclPopulated := &Source{Data: "secret", ID: 1} // want "source identified"
 
 	alias := Alias{} // want "source identified"
 	def := Definition{}
 
-	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulataed, alias, def)
+	noop(varZeroVal, declZeroVal, populatedVal, constPtr, ptr, newPtr, ptrToDeclZero, ptrToDeclPopulated, alias, def)
 }
 
 // A report should be emitted for each parameter, as well as the (implicit) Alloc for val.


### PR DESCRIPTION
- [ ] Running against a large codebase such as [Kubernetes](https://github.com/kubernetes/kubernetes) does not error out. (See [DEVELOPING.md](https://github.com/google/go-flow-levee/blob/master/DEVELOPING.md) for instructions on how to do that.)
- [ ] Appropriate changes to README are included in PR
